### PR TITLE
Minor spelling error in case.py process_forcings().

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -388,7 +388,7 @@ class Case:
         if self.tidal_constituents:
 
             if self.ocn_grid.is_rectangular():
-                boundary_type = "rectangle"
+                boundary_type = "rectangular"
             else:
                 boundary_type = "curvilinear"
 


### PR DESCRIPTION
**Description:**
There was a bug found when calling `case.process_forcings()` in minimal_demo_rect.ipynb. Process_forcings sets the boundary_type="rectangle" which throws an error when regional_mom6.py function setup_boundary_tides() checks that the boundary_type is either "rectangular" or "curvilinear." 

**Major Changes**
Adjusted the boundary_type assignment in process_forcings() to `boundary_type="rectangular"`