### PR TITLE
Remove boundary_type in CrocoDash

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -386,18 +386,12 @@ class Case:
 
         # Process the tides
         if self.tidal_constituents:
-
-            if self.ocn_grid.is_rectangular():
-                boundary_type = "rectangular"
-            else:
-                boundary_type = "curvilinear"
-
+            
             # Process the tides
             self.expt.setup_boundary_tides(
                 tpxo_elevation_filepath=self.tpxo_elevation_filepath,
                 tpxo_velocity_filepath=self.tpxo_velocity_filepath,
                 tidal_constituents=self.tidal_constituents,
-                boundary_type=boundary_type,
             )
 
         # regional_mom6 places OBC files under inputdir/forcing. Move them to inputdir:


### PR DESCRIPTION
When this is removed in RM6, we'll merge this one.