### PR TITLE
Add River Nutrients Mapping + (Empty) Iron Forcing Generation for BGC

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -26,6 +26,8 @@ from visualCaseGen.custom_widget_types.case_creator import CaseCreator, ERROR, R
 from visualCaseGen.custom_widget_types.case_tools import xmlchange, append_user_nl
 from mom6_bathy import chl, mapping, grid
 import xesmf as xe
+import xarray as xr 
+import numpy as np
 
 class Case:
     """This class represents a regional MOM6 case within the CESM framework. It is similar to the
@@ -1227,6 +1229,8 @@ class Case:
         if self.bgc_in_compset:
             bgc_params = [
                 ("MAX_FIELDS", "200"),
+                ("MARBL_FESEDFLUX_FILE",self.fesedflux_filepath),
+                ("MARBL_FEVENTFLUX_FILE",self.feventflux_filepath)
             ]
 
 

--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -391,13 +391,13 @@ class Case:
         else:
             self.configured_river_nutrients = False
         
-        if bgc_in_compset:
-            self.configured_bgc = self.configure_bgc()
+        if self.bgc_in_compset:
+            self.configured_bgc = self.configure_bgc_iron_forcing()
         else:
             self.configured_bgc = False
         self._configure_forcings_called = True
 
-    def configure_bgc(self):
+    def configure_bgc_iron_forcing(self):
         self.feventflux_filepath = self.inputdir / "ocnice" / f"feventflux_5gmol_{self.grid.name}_{cvars['MB_ATTEMPT_ID'].value}.nc"
         self.fesedflux_filepath = self.inputdir / "ocnice" / f"fesedflux_total_reduce_oxic_{self.grid.name}_{cvars['MB_ATTEMPT_ID'].value}.nc"
         return True
@@ -534,7 +534,7 @@ class Case:
                 process_initial_condition, process_velocity_tracers
             )
         if self.configured_bgc and process_bgc:
-            self.process_bgc()
+            self.process_bgc_iron_forcing()
         if self.configured_tides and process_tides:
             self.process_tides()
         if self.configured_chl and process_chl:
@@ -548,7 +548,7 @@ class Case:
         if process_param_changes:
             self._update_forcing_variables()
 
-    def process_bgc(self):
+    def process_bgc_iron_forcing(self):
         # Create coordinate variables
         nx = self.grid.nx 
         ny = self.grid.ny

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -173,7 +173,9 @@ def test_update_forcing_variables(get_CrocoDash_case):
             dt.datetime.strptime("2020-01-01", "%Y-%m-%d"),
             dt.datetime.strptime("2020-02-01", "%Y-%m-%d"),
         ]
+    case.forcing_product_name = "glorys"
     case.runoff_esmf_mesh_filepath = True
+    case.bgc_in_compset = False
     case.runoff_mapping_file_nnsm = "Path"
     case.cice_file = "Path"
     case.configured_tides = True


### PR DESCRIPTION
Changes:

1. Offline mapping for a passed-in river nutrients file w/ Unit Conversion & Adding a timestep
2. Generates an empty file for iron forcing files for bgc runs

Background:

This uses the "configure" and "process" workflow.