### PR TITLE
Move the parameter updates to configure_forcings

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -387,7 +387,7 @@ class Case:
             raise ValueError("Product / Data Path is not supported quite yet")
         if tidal_constituents:
             self.configured_tides = self.configure_tides(
-                tidal_constituents, tpxo_elevation_filepath, tpxo_velocity_filepath
+                tidal_constituents, tpxo_elevation_filepath, tpxo_velocity_filepath, boundaries
             )
         else:
             self.configured_tides = False


### PR DESCRIPTION
Currently, we update `user_nl_mom `& add xml changes in `process_forcings `under the name `update_forcing_variables`. If process forcings fails, we miss out on all of the param changes (which executes last).

This PR moves it to `configure_forcings`. It doesn't take very long, so it would not add much time to the `configure_forcings `execution time, and should only rely on `configure_forcings `changes anyway. This is nice because it leads to the only changes process_forcings makes are in the input directory.