### PR TITLE
Warn when configure_forcings() is called more than once

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -419,6 +419,14 @@ class Case:
         process_forcings : Executes the actual boundary, initial condition, and tide setup based on the configuration.
         """
 
+        if self._configure_forcings_called:
+            print(
+                "WARNING: configure_forcings() has already been called. "
+                "Parameters will be written to user_nl_mom again, creating duplicates. "
+                "You will need to manually remove the duplicate entries from user_nl_mom "
+                "before running the case."
+            )
+
         # Set up Forcings Folder
         self.extract_forcings_path = self.inputdir / "extract_forcings"
         if self.override is True:


### PR DESCRIPTION
Closes #228

Prints a warning if `configure_forcings()` is called a second time, since each call appends duplicate parameters to `user_nl_mom`, which will break the CESM run. The user is told to manually remove the duplicates before running the case.