### PR TITLE
Add rudimentary nesting through a raw data access product

### DIFF
--- a/CrocoDash/raw_data_access/datasets/nesting.py
+++ b/CrocoDash/raw_data_access/datasets/nesting.py
@@ -51,12 +51,11 @@ class NESTING(ForcingProduct):
         lat_max=None,
         output_folder=Path(""),
         output_filename="nesting_slices.nc",
-        output_dir=None,
+        input_dir=None,
         case_prefix="",
-        slices=None,
     ):
         """
-        Check whether nesting slice output files exist in output_dir for each named
+        Check whether nesting slice output files exist in input_dir for each named
         cross-section in slices. If all files are found and cover the requested dates,
         load and save them to output_folder/output_filename (one NetCDF group per slice)
         and return the output path. If any slice files are missing or dates are not
@@ -66,7 +65,7 @@ class NESTING(ForcingProduct):
         ----------
         dates : list
             [start_date, end_date] strings, e.g. ["2020-01-01", "2020-03-31"]
-        output_dir : Path or str
+        input_dir : Path or str
             Parent MOM6/CESM run history directory to search for slice files.
         case_prefix : str
             Prefix used in diag_table file names, e.g. "carib12_credit_runoff_01.mom6"
@@ -76,36 +75,37 @@ class NESTING(ForcingProduct):
         """
         if variables is None:
             variables = NESTING.SLICE_VARIABLES
-        if not slices:
-            NESTING.logger.warning("No slices provided — nothing to load or configure.")
-            return None
 
         output_folder = Path(output_folder)
-        output_dir = Path(output_dir) if output_dir is not None else None
+        input_dir = Path(input_dir) if input_dir is not None else None
 
         # --- Step 1: Locate files for each slice ---
         found_files = {}
         missing_slices = []
 
-        for s in slices:
-            name = s["name"]
-            if output_dir is not None and output_dir.is_dir():
-                matches = sorted(output_dir.glob(f"{case_prefix}.{name}*.nc"))
-                if matches:
-                    found_files[name] = matches
-                else:
-                    missing_slices.append(name)
+        if input_dir is not None and input_dir.is_dir():
+            matches = sorted(input_dir.glob(f"{case_prefix}.{name}*.nc"))
+            if matches:
+                found_files = matches
             else:
-                missing_slices.append(name)
+                missing_slices = True
+        else:
+            missing_slices = True
 
         # --- Step 2: Missing files → print diag_table config and exit ---
         if missing_slices:
             NESTING.logger.warning(
-                f"Slice files not found for: {missing_slices}. "
+                f"Slice files not found in {input_dir}. "
                 "Add the entries below to your parent run's diag_table and rerun."
             )
             diag_text = _build_diag_table_entries(
-                slices, case_prefix, NESTING.BUFFER_DEG
+                "bound",
+                lon_min,
+                lon_max,
+                lat_min,
+                lat_max,
+                case_prefix,
+                NESTING.BUFFER_DEG,
             )
             print(
                 "\n=== Add these entries to your parent run's diag_table ===\n"
@@ -152,28 +152,28 @@ class NESTING(ForcingProduct):
         return output_path
 
 
-def _build_diag_table_entries(slices, case_prefix, buffer_deg=0.5):
+def _build_diag_table_entries(
+    name, lon_min, lon_max, lat_min, lat_max, case_prefix, buffer_deg=0.5
+):
     """Return a diag_table-formatted string for a list of nesting cross-sections."""
     variables = ["volcello", "thetao", "so", "uo", "vo", "zos"]
 
     file_lines = []
     field_lines = []
 
-    for s in slices:
-        name = s["name"]
-        file_name = f"{case_prefix}.{name}%4yr-%2mo"
-        region = (
-            f"{s['lon_min'] - buffer_deg} {s['lon_max'] + buffer_deg} "
-            f"{s['lat_min'] - buffer_deg} {s['lat_max'] + buffer_deg}  -1 -1"
-        )
+    file_name = f"{case_prefix}.{name}%4yr-%2mo"
+    region = (
+        f"{lon_min - buffer_deg} {lon_max + buffer_deg} "
+        f"{lat_min - buffer_deg} {lat_max + buffer_deg}  -1 -1"
+    )
 
-        file_lines.append(
-            f'"{file_name}",  1,  "days",  1,  "days",  "time",  1,  "months"'
+    file_lines.append(
+        f'"{file_name}",  1,  "days",  1,  "days",  "time",  1,  "months"'
+    )
+    for var in variables:
+        field_lines.append(
+            f'"ocean_model_z", "{var}", "{var}", "{file_name}", "all", "mean", "{region}", 2'
         )
-        for var in variables:
-            field_lines.append(
-                f'"ocean_model_z", "{var}", "{var}", "{file_name}", "all", "mean", "{region}", 2'
-            )
 
     return (
         "# --- File entries ---\n"

--- a/CrocoDash/raw_data_access/datasets/nesting.py
+++ b/CrocoDash/raw_data_access/datasets/nesting.py
@@ -44,11 +44,12 @@ class NESTING(ForcingProduct):
     )
     def get_nesting_slices(
         dates: list,
-        variables=None,
-        lon_min=None,
-        lon_max=None,
-        lat_min=None,
-        lat_max=None,
+        variables,
+        lon_min,
+        lon_max,
+        lat_min,
+        lat_max,
+        name,
         output_folder=Path(""),
         output_filename="nesting_slices.nc",
         input_dir=None,

--- a/CrocoDash/raw_data_access/datasets/nesting.py
+++ b/CrocoDash/raw_data_access/datasets/nesting.py
@@ -99,7 +99,7 @@ class NESTING(ForcingProduct):
                 "Add the entries below to your parent run's diag_table and rerun."
             )
             diag_text = _build_diag_table_entries(
-                "bound",
+                "[nameofboundary]",
                 lon_min,
                 lon_max,
                 lat_min,

--- a/CrocoDash/raw_data_access/datasets/nesting.py
+++ b/CrocoDash/raw_data_access/datasets/nesting.py
@@ -100,7 +100,7 @@ class NESTING(ForcingProduct):
                 "Add the entries below to your parent run's diag_table and rerun."
             )
             diag_text = _build_diag_table_entries(
-                "[nameofboundary]",
+                name,
                 lon_min,
                 lon_max,
                 lat_min,

--- a/CrocoDash/raw_data_access/datasets/nesting.py
+++ b/CrocoDash/raw_data_access/datasets/nesting.py
@@ -1,0 +1,192 @@
+"""
+Data Access Module -> NESTING
+
+Provides diag_table entries for 3D cross-section slices from a parent MOM6 run,
+and loads those slices for use as OBC forcing in a nested child domain.
+"""
+
+import xarray as xr
+import pandas as pd
+from pathlib import Path
+
+from CrocoDash.raw_data_access.base import *
+
+
+class NESTING(ForcingProduct):
+    product_name = "nesting"
+    description = "MOM6 regional nesting cross-section slices for use as OBC forcing in a nested child domain run"
+    link = "https://mom6.readthedocs.io/en/main/api/generated/pages/Diagnostics.html"
+
+    time_var_name = "time"
+    time_units = "days"
+    boundary_fill_method = "regional_mom6"
+    u_var_name = "uo"
+    v_var_name = "vo"
+    eta_var_name = "zos"
+    depth_coord = "z_l"
+    tracer_x_coord = "xh"
+    tracer_y_coord = "yh"
+    u_x_coord = "xq"
+    u_y_coord = "yh"
+    v_x_coord = "xh"
+    v_y_coord = "yq"
+    tracer_var_names = {"temp": "thetao", "salt": "so"}
+
+    SLICE_VARIABLES = ["volcello", "thetao", "so", "uo", "vo", "zos"]
+    BUFFER_DEG = 0.5
+
+    @accessmethod(
+        description=(
+            "Load nesting slice output from a parent MOM6 run directory, "
+            "or print diag_table entries if slice files are not yet present"
+        ),
+        type="python",
+    )
+    def get_nesting_slices(
+        dates: list,
+        variables=None,
+        lon_min=None,
+        lon_max=None,
+        lat_min=None,
+        lat_max=None,
+        output_folder=Path(""),
+        output_filename="nesting_slices.nc",
+        output_dir=None,
+        case_prefix="",
+        slices=None,
+    ):
+        """
+        Check whether nesting slice output files exist in output_dir for each named
+        cross-section in slices. If all files are found and cover the requested dates,
+        load and save them to output_folder/output_filename (one NetCDF group per slice)
+        and return the output path. If any slice files are missing or dates are not
+        covered, print the diag_table entries needed for the parent run and return None.
+
+        Parameters
+        ----------
+        dates : list
+            [start_date, end_date] strings, e.g. ["2020-01-01", "2020-03-31"]
+        output_dir : Path or str
+            Parent MOM6/CESM run history directory to search for slice files.
+        case_prefix : str
+            Prefix used in diag_table file names, e.g. "carib12_credit_runoff_01.mom6"
+        slices : list of dict
+            Each dict: {"name": str, "lon_min": float, "lon_max": float,
+                        "lat_min": float, "lat_max": float}
+        """
+        if variables is None:
+            variables = NESTING.SLICE_VARIABLES
+        if not slices:
+            NESTING.logger.warning("No slices provided — nothing to load or configure.")
+            return None
+
+        output_folder = Path(output_folder)
+        output_dir = Path(output_dir) if output_dir is not None else None
+
+        # --- Step 1: Locate files for each slice ---
+        found_files = {}
+        missing_slices = []
+
+        for s in slices:
+            name = s["name"]
+            if output_dir is not None and output_dir.is_dir():
+                matches = sorted(output_dir.glob(f"{case_prefix}.{name}*.nc"))
+                if matches:
+                    found_files[name] = matches
+                else:
+                    missing_slices.append(name)
+            else:
+                missing_slices.append(name)
+
+        # --- Step 2: Missing files → print diag_table config and exit ---
+        if missing_slices:
+            NESTING.logger.warning(
+                f"Slice files not found for: {missing_slices}. "
+                "Add the entries below to your parent run's diag_table and rerun."
+            )
+            diag_text = _build_diag_table_entries(
+                slices, case_prefix, NESTING.BUFFER_DEG
+            )
+            print(
+                "\n=== Add these entries to your parent run's diag_table ===\n"
+                + diag_text
+            )
+            return None
+
+        # --- Step 3: Date coverage check ---
+        start_ts = pd.Timestamp(dates[0])
+        end_ts = pd.Timestamp(dates[-1])
+        coverage_ok = True
+
+        for name, file_paths in found_files.items():
+            ds = xr.open_mfdataset(
+                file_paths, combine="by_coords", decode_timedelta=False
+            )
+            t_min = _to_timestamp(ds.time.values[0])
+            t_max = _to_timestamp(ds.time.values[-1])
+            if t_min > start_ts or t_max < end_ts:
+                NESTING.logger.warning(
+                    f"Slice '{name}' covers {t_min.date()} → {t_max.date()} "
+                    f"but {start_ts.date()} → {end_ts.date()} was requested."
+                )
+                coverage_ok = False
+
+        if not coverage_ok:
+            NESTING.logger.warning(
+                "Date coverage check failed. Check that your parent run covers the full date range."
+            )
+            return None
+
+        # --- Step 4: Load, time-filter, and save per-slice groups ---
+        output_path = output_folder / output_filename
+        mode = "w"
+        for name, file_paths in found_files.items():
+            ds = xr.open_mfdataset(
+                file_paths, combine="by_coords", decode_timedelta=False
+            )
+            ds = ds.sel(time=slice(start_ts, end_ts))
+            ds.to_netcdf(output_path, mode=mode, group=name)
+            mode = "a"
+
+        NESTING.logger.info(f"Nesting slices saved to {output_path}")
+        return output_path
+
+
+def _build_diag_table_entries(slices, case_prefix, buffer_deg=0.5):
+    """Return a diag_table-formatted string for a list of nesting cross-sections."""
+    variables = ["volcello", "thetao", "so", "uo", "vo", "zos"]
+
+    file_lines = []
+    field_lines = []
+
+    for s in slices:
+        name = s["name"]
+        file_name = f"{case_prefix}.{name}%4yr-%2mo"
+        region = (
+            f"{s['lon_min'] - buffer_deg} {s['lon_max'] + buffer_deg} "
+            f"{s['lat_min'] - buffer_deg} {s['lat_max'] + buffer_deg}  -1 -1"
+        )
+
+        file_lines.append(
+            f'"{file_name}",  1,  "days",  1,  "days",  "time",  1,  "months"'
+        )
+        for var in variables:
+            field_lines.append(
+                f'"ocean_model_z", "{var}", "{var}", "{file_name}", "all", "mean", "{region}", 2'
+            )
+
+    return (
+        "# --- File entries ---\n"
+        + "\n".join(file_lines)
+        + "\n\n# --- Field entries ---\n"
+        + "\n".join(field_lines)
+        + "\n"
+    )
+
+
+def _to_timestamp(t):
+    """Convert a time value (numpy datetime64, cftime, str) to pandas Timestamp."""
+    try:
+        return pd.Timestamp(t)
+    except Exception:
+        return pd.Timestamp(str(t))

--- a/tests/raw_data_access/test_nesting.py
+++ b/tests/raw_data_access/test_nesting.py
@@ -1,0 +1,174 @@
+from CrocoDash.raw_data_access.datasets import nesting as ns
+from CrocoDash.raw_data_access.datasets.nesting import _build_diag_table_entries
+from CrocoDash.raw_data_access.registry import ProductRegistry
+import xarray as xr
+import numpy as np
+import pandas as pd
+import pytest
+
+SAMPLE_SLICES = [
+    {
+        "name": "Florida_Cuba",
+        "lon_min": -80.529,
+        "lon_max": -80.529,
+        "lat_min": 22.894,
+        "lat_max": 25.223,
+    },
+    {
+        "name": "Florida_Strait",
+        "lon_min": -80.115,
+        "lon_max": -78.869,
+        "lat_min": 26.636,
+        "lat_max": 26.636,
+    },
+]
+CASE_PREFIX = "test_case.mom6"
+DATES = ["2020-01-01", "2020-03-31"]
+BUFFER = ns.NESTING.BUFFER_DEG
+
+
+# --- Registration ---
+
+
+def test_product_registered():
+    ProductRegistry.load()
+    assert ProductRegistry.product_exists("nesting")
+    assert "get_nesting_slices" in ProductRegistry.list_access_methods("nesting")
+
+
+def test_forcing_product_metadata():
+    assert ns.NESTING.tracer_var_names == {"temp": "thetao", "salt": "so"}
+    assert ns.NESTING.u_var_name == "uo"
+    assert ns.NESTING.v_var_name == "vo"
+    assert ns.NESTING.eta_var_name == "zos"
+
+
+# --- Diag table generation ---
+
+
+def test_diag_table_contains_all_slices():
+    text = _build_diag_table_entries(SAMPLE_SLICES, CASE_PREFIX)
+    for s in SAMPLE_SLICES:
+        assert s["name"] in text
+
+
+def test_diag_table_buffer_applied():
+    text = _build_diag_table_entries(SAMPLE_SLICES, CASE_PREFIX, buffer_deg=0.5)
+    # Florida_Cuba: lon buffered from -80.529±0.5, lat buffered from 22.894-0.5 to 25.223+0.5
+    assert "-81.029" in text
+    assert "-80.029" in text
+    assert "22.394" in text
+    assert "25.723" in text
+
+
+def test_diag_table_all_variables():
+    text = _build_diag_table_entries(SAMPLE_SLICES, CASE_PREFIX)
+    for var in ns.NESTING.SLICE_VARIABLES:
+        assert var in text
+
+
+def test_diag_table_file_section_format():
+    text = _build_diag_table_entries([SAMPLE_SLICES[0]], CASE_PREFIX)
+    assert f'"{CASE_PREFIX}.Florida_Cuba%4yr-%2mo"' in text
+    assert '"ocean_model_z"' in text
+    assert '"all", "mean"' in text
+
+
+def test_diag_table_vert_bounds():
+    text = _build_diag_table_entries(SAMPLE_SLICES, CASE_PREFIX)
+    assert "-1 -1" in text
+
+
+# --- Missing files path ---
+
+
+def test_missing_output_dir_returns_none_and_prints(tmp_path, capsys):
+    result = ns.NESTING.get_nesting_slices(
+        dates=DATES,
+        output_dir=tmp_path,  # empty dir — no files
+        case_prefix=CASE_PREFIX,
+        slices=SAMPLE_SLICES,
+        output_folder=tmp_path,
+    )
+    assert result is None
+    captured = capsys.readouterr()
+    assert "diag_table" in captured.out
+    assert "Florida_Cuba" in captured.out
+
+
+def test_none_output_dir_returns_none(tmp_path, capsys):
+    result = ns.NESTING.get_nesting_slices(
+        dates=DATES,
+        output_dir=None,
+        case_prefix=CASE_PREFIX,
+        slices=SAMPLE_SLICES,
+        output_folder=tmp_path,
+    )
+    assert result is None
+
+
+def test_empty_slices_returns_none(tmp_path):
+    result = ns.NESTING.get_nesting_slices(
+        dates=DATES,
+        output_dir=tmp_path,
+        case_prefix=CASE_PREFIX,
+        slices=[],
+        output_folder=tmp_path,
+    )
+    assert result is None
+
+
+# --- Date coverage check ---
+
+
+def _write_mock_slice(output_dir, case_prefix, slice_name, times):
+    """Write a minimal mock slice NetCDF file."""
+    ds = xr.Dataset(
+        {
+            "thetao": (["time", "z_l", "xh", "yh"], np.ones((len(times), 2, 3, 3))),
+        },
+        coords={
+            "time": times,
+            "z_l": [5.0, 50.0],
+            "xh": [0.0, 1.0, 2.0],
+            "yh": [0.0, 1.0, 2.0],
+        },
+    )
+    path = output_dir / f"{case_prefix}.{slice_name}_mock.nc"
+    ds.to_netcdf(path)
+    return path
+
+
+def test_date_coverage_check_fails_when_data_too_short(tmp_path):
+    times = pd.date_range("2020-01-01", "2020-01-31", freq="D")
+    for s in SAMPLE_SLICES:
+        _write_mock_slice(tmp_path, CASE_PREFIX, s["name"], times)
+
+    result = ns.NESTING.get_nesting_slices(
+        dates=["2020-01-01", "2020-06-30"],  # requests beyond available data
+        output_dir=tmp_path,
+        case_prefix=CASE_PREFIX,
+        slices=SAMPLE_SLICES,
+        output_folder=tmp_path,
+    )
+    assert result is None
+
+
+def test_loads_and_saves_when_coverage_ok(tmp_path):
+    times = pd.date_range("2020-01-01", "2020-04-30", freq="D")
+    for s in SAMPLE_SLICES:
+        _write_mock_slice(tmp_path, CASE_PREFIX, s["name"], times)
+
+    result = ns.NESTING.get_nesting_slices(
+        dates=DATES,
+        output_dir=tmp_path,
+        case_prefix=CASE_PREFIX,
+        slices=SAMPLE_SLICES,
+        output_folder=tmp_path,
+        output_filename="out.nc",
+    )
+    assert result is not None
+    assert result.exists()
+    # verify groups are present
+    ds_check = xr.open_dataset(result, group="Florida_Cuba")
+    assert "thetao" in ds_check


### PR DESCRIPTION
## Summary

- Adds `NESTING(ForcingProduct)` in `raw_data_access/datasets/nesting.py`
- Single `get_nesting_slices()` access method: checks for existing parent-run slice files, validates date coverage, loads and saves them (one NetCDF group per cross-section); prints `diag_table` entries with 0.5° buffer if files are missing
- 12 unit tests covering registration, diag_table format, missing-files path, date coverage, and happy-path load

## Test plan
- [x] `conda run -n CrocoDash pytest tests/raw_data_access/test_nesting.py -vv`
- [ ] Manual: drop generated diag_table entries into a parent run and verify slice files are produced