### PR TITLE
Fix OBC/GLORYS antimeridian bugs found building polar test domains

### DIFF
--- a/CrocoDash/extract_forcings/obc.py
+++ b/CrocoDash/extract_forcings/obc.py
@@ -248,13 +248,16 @@ def _regrid_boundary(
             continue
 
         tmp_file = output_folder / f"_tmp_{boundary}_{start_str}_{end_str}.nc"
-        # Raw product timestamps (e.g. GLORYS daily means) are stamped at
-        # noon, not midnight — push chunk_end to end-of-day so label-based
-        # .sel() doesn't silently drop the last day's sample at each chunk
-        # boundary. Mirrors make_dates_end_inclusive in raw_data_access.
-        chunk_end_inclusive = chunk_end + timedelta(hours=23, minutes=59, seconds=59)
-        end_str = chunk_end_inclusive.strftime("%Y-%m-%d")
-        ds_full.sel(time=slice(start_str, end_str)).to_netcdf(tmp_file)
+        # chunk_start/chunk_end are midnight-anchored dates, but daily-mean products
+        # like GLORYS timestamp each day's value at noon. A plain slice(chunk_start,
+        # chunk_end) therefore excludes chunk_end's own data point (it falls after
+        # the midnight upper bound) -- silently dropping the chunk's last day, and
+        # producing a fully empty selection for any single-day chunk (e.g. the
+        # trailing remainder when the date range isn't a multiple of
+        # regrid_step_days), which crashes downstream on a zero-size array. Extend
+        # the upper bound through the end of chunk_end's calendar day.
+        chunk_end_of_day = chunk_end + timedelta(hours=23, minutes=59, seconds=59)
+        ds_full.sel(time=slice(chunk_start, chunk_end_of_day)).to_netcdf(tmp_file)
 
         try:
             seg = rm6.segment(

--- a/CrocoDash/extract_forcings/obc.py
+++ b/CrocoDash/extract_forcings/obc.py
@@ -248,16 +248,11 @@ def _regrid_boundary(
             continue
 
         tmp_file = output_folder / f"_tmp_{boundary}_{start_str}_{end_str}.nc"
-        # chunk_start/chunk_end are midnight-anchored dates, but daily-mean products
-        # like GLORYS timestamp each day's value at noon. A plain slice(chunk_start,
-        # chunk_end) therefore excludes chunk_end's own data point (it falls after
-        # the midnight upper bound) -- silently dropping the chunk's last day, and
-        # producing a fully empty selection for any single-day chunk (e.g. the
-        # trailing remainder when the date range isn't a multiple of
-        # regrid_step_days), which crashes downstream on a zero-size array. Extend
-        # the upper bound through the end of chunk_end's calendar day.
-        chunk_end_of_day = chunk_end + timedelta(hours=23, minutes=59, seconds=59)
-        ds_full.sel(time=slice(chunk_start, chunk_end_of_day)).to_netcdf(tmp_file)
+        # Daily-mean products like GLORYS timestamp each day's value at noon, so
+        # slice by date strings (pandas partial-string indexing treats the end
+        # string as covering that whole calendar day) to include chunk_end's own
+        # data point instead of a midnight-anchored datetime slice excluding it.
+        ds_full.sel(time=slice(start_str, end_str)).to_netcdf(tmp_file)
 
         try:
             seg = rm6.segment(

--- a/CrocoDash/raw_data_access/datasets/glorys.py
+++ b/CrocoDash/raw_data_access/datasets/glorys.py
@@ -82,6 +82,11 @@ class GLORYS(ForcingProduct):
 
         # Adjust lat lon inputs to make sure they are in the correct range of -180 to 180
         lon_min, lon_max = convert_lons_to_180_range(lon_min, lon_max)
+        # 180 and -180 are the same meridian, but the conversion above always
+        # picks -180 -- undo that for lon_max so a contiguous box like
+        # 100..180 doesn't wrongly take the wrap branch below.
+        if lon_max == -180:
+            lon_max = 180
 
         for date in date_strings:
             pattern = os.path.join(ds_in_path, "**", f"*_{date}_*.nc")
@@ -123,9 +128,18 @@ class GLORYS(ForcingProduct):
                 dim="longitude",
             )
 
-            # convert longitude from degree west to degree east
-            dataset["longitude"] = (360 - dataset["longitude"]) % 360
+            # The two slices above are still in the native -180..180 system, so
+            # concatenating them gives a non-monotonic sequence across the wrap
+            # (e.g. ...,179,180,-180,-179,...). Shift into a continuous 0..360
+            # range -- lon % 360 leaves the eastern slice (169..180) untouched
+            # and maps the western slice (-180..-169) to 180..191 -- so the
+            # combined array sorts into one ascending run across the seam.
+            dataset["longitude"] = dataset["longitude"] % 360
             dataset = dataset.sortby("longitude")
+            # Near-full-circle boxes leave a gap narrower than the combined
+            # 2deg buffer, so the slices above can overlap and duplicate
+            # longitudes -- keep the first occurrence.
+            dataset = dataset.drop_duplicates("longitude")
 
         dataset.to_netcdf(path)
         return path

--- a/CrocoDash/raw_data_access/datasets/glorys.py
+++ b/CrocoDash/raw_data_access/datasets/glorys.py
@@ -92,7 +92,18 @@ class GLORYS(ForcingProduct):
             ds_in_files, decode_times=False, engine="h5netcdf", parallel=True
         )[variables]
 
-        if lon_min * lon_max > 0:
+        # lon_min <= lon_max is already a valid ascending range in the -180..180
+        # system -- true whether it's a normal same-sign box (e.g. -80..-70) or one
+        # that happens to straddle the prime meridian (e.g. -45..45) -- so a direct
+        # slice is correct either way. Splitting is only needed when the range
+        # actually wraps around the antimeridian (lon_min > lon_max, e.g. 170..-170).
+        # The previous `lon_min * lon_max > 0` (same-sign) check wrongly routed any
+        # opposite-sign range into the split/concat branch too, including
+        # prime-meridian-straddling boxes -- there, the two slices
+        # slice(lon_min-1, 360) and slice(-180, lon_max+1) overlap heavily (both
+        # cover the whole middle region) instead of being disjoint, duplicating a
+        # large swath of longitude values in the concatenated result.
+        if lon_min <= lon_max:
             dataset = ds.sel(
                 latitude=slice(lat_min - 1, lat_max + 1),
                 longitude=slice(lon_min - 1, lon_max + 1),

--- a/tests/extract_forcings/test_obc.py
+++ b/tests/extract_forcings/test_obc.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import pandas as pd
 import xarray as xr
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +12,27 @@ from CrocoDash.extract_forcings.obc import (
 )
 from CrocoDash.extract_forcings.utils import is_valid_netcdf
 from CrocoDash.grid import Grid
+
+
+def test_date_string_slice_includes_noon_stamped_trailing_day():
+    """The per-regrid-chunk slice uses date strings (not chunk_start/chunk_end
+    datetimes) because pandas partial-string indexing covers the end string's
+    whole calendar day. Daily-mean products like GLORYS stamp each day's value
+    at noon, so a midnight-anchored datetime slice would exclude a single-day
+    trailing chunk (e.g. a date range that isn't an exact multiple of
+    regrid_step_days) entirely, crashing downstream on a zero-size array.
+    """
+    times = pd.date_range("2020-01-01 12:00", periods=16, freq="D")
+    ds_full = xr.Dataset({"var": ("time", np.arange(16))}, coords={"time": times})
+
+    chunk_start, chunk_end = datetime(2020, 1, 16), datetime(2020, 1, 16)
+    start_str = chunk_start.strftime("%Y-%m-%d")
+    end_str = chunk_end.strftime("%Y-%m-%d")
+
+    sliced = ds_full.sel(time=slice(start_str, end_str))
+    assert sliced.sizes["time"] == 1
+    assert sliced.time.values[0] == np.datetime64("2020-01-16T12:00:00")
+
 
 # ---------------------------------------------------------------------------
 # Fixture: minimal config.json that process_obc_conditions can load

--- a/tests/raw_data_access/test_glorys.py
+++ b/tests/raw_data_access/test_glorys.py
@@ -5,6 +5,134 @@ import xarray as xr
 import numpy as np
 
 
+def test_get_glorys_data_from_rda_antimeridian_wrap_no_mirror(tmp_path, monkeypatch):
+    """A box that wraps the antimeridian (lon_min > lon_max, e.g. 170..-170)
+    splits into an eastern (169..180) and western (-180..-169) slice, then
+    shifts the western slice into 180..191 so the concatenated result sorts
+    into one ascending run across the seam. The shift must be `lon % 360`
+    (a pure translation) -- `(360 - lon) % 360` is a reflection that swaps
+    which hemisphere's data ends up on which side of the dateline, and a
+    plain "sorted, no duplicate longitudes" check can't tell the two apart
+    since both produce the same set of longitude *values*, just paired with
+    the wrong data.
+
+    Tags each raw longitude's data with its own (unshifted, native -180..180)
+    value, so after the transform we can check the data followed its label
+    instead of only checking the label set.
+    """
+    lat = np.array([30.0, 31.0])
+    lon = np.arange(-180.0, 181.0, 1.0)
+    zos = np.broadcast_to(lon, (1, len(lat), len(lon))).copy()
+    fake_ds = xr.Dataset(
+        {"zos": (("time", "latitude", "longitude"), zos)},
+        coords={"time": [0], "latitude": lat, "longitude": lon},
+    )
+
+    monkeypatch.setattr(gl.glob, "glob", lambda *a, **k: ["dummy.nc"])
+    monkeypatch.setattr(gl.xr, "open_mfdataset", lambda *a, **k: fake_ds)
+
+    dataset_path = gl.GLORYS.get_glorys_data_from_rda(
+        ["2000-01-01", "2000-01-01"],
+        30,
+        31,
+        170,
+        -170,
+        tmp_path,
+        "temp.nc",
+        variables=["zos"],
+    )
+    result = xr.open_dataset(dataset_path)
+    out_lon = result.longitude.values
+    out_zos = result.zos.isel(time=0, latitude=0).values
+
+    assert np.all(np.diff(out_lon) >= 0)  # ascending across the seam
+
+    for final_lon, value in zip(out_lon, out_zos):
+        # 180 is a shared boundary point: it's produced both by the eastern
+        # slice's own 180 and by the western slice's -180 mapping to 180, so
+        # either raw value is valid there.
+        if final_lon == 180.0:
+            assert value in (
+                pytest.approx(180.0),
+                pytest.approx(-180.0),
+            ), f"longitude 180 carries unexpected raw longitude {value}"
+            continue
+        expected_raw = final_lon if final_lon < 180 else final_lon - 360
+        assert value == pytest.approx(expected_raw), (
+            f"longitude {final_lon} carries data from raw longitude {value}, "
+            f"expected {expected_raw} -- data did not follow its label across "
+            "the antimeridian shift"
+        )
+
+
+def _fake_full_globe_ds():
+    lat = np.array([30.0, 31.0])
+    lon = np.arange(-180.0, 181.0, 1.0)
+    zos = np.broadcast_to(lon, (1, len(lat), len(lon))).copy()
+    return xr.Dataset(
+        {"zos": (("time", "latitude", "longitude"), zos)},
+        coords={"time": [0], "latitude": lat, "longitude": lon},
+    )
+
+
+def test_get_glorys_data_from_rda_lon_max_exactly_180_is_not_a_wrap(
+    tmp_path, monkeypatch
+):
+    """convert_lons_to_180_range maps a lon_max of exactly 180 to -180 (both
+    represent the same meridian). A box like 100..180 must still take the
+    contiguous (non-wrap) branch instead of being misrouted into the
+    split/concat wrap branch by that relabeling.
+    """
+    fake_ds = _fake_full_globe_ds()
+    monkeypatch.setattr(gl.glob, "glob", lambda *a, **k: ["dummy.nc"])
+    monkeypatch.setattr(gl.xr, "open_mfdataset", lambda *a, **k: fake_ds)
+
+    dataset_path = gl.GLORYS.get_glorys_data_from_rda(
+        ["2000-01-01", "2000-01-01"],
+        30,
+        31,
+        100,
+        180,
+        tmp_path,
+        "temp.nc",
+        variables=["zos"],
+    )
+    result = xr.open_dataset(dataset_path)
+    out_lon = result.longitude.values
+
+    assert out_lon.min() == pytest.approx(99.0)  # lon_min - 1 buffer
+    assert out_lon.max() == pytest.approx(180.0)  # native range caps at 180
+    assert len(out_lon) == len(np.unique(out_lon))  # no wrap-branch duplicates
+
+
+def test_get_glorys_data_from_rda_near_global_box_has_no_duplicate_longitudes(
+    tmp_path, monkeypatch
+):
+    """A near-full-circle box (lon_min/lon_max both close to the same
+    meridian, e.g. 0.5..-0.5) leaves an excluded gap narrower than the
+    combined 2deg buffer, so the wrap branch's two slices overlap and would
+    otherwise duplicate longitude values around the gap edges.
+    """
+    fake_ds = _fake_full_globe_ds()
+    monkeypatch.setattr(gl.glob, "glob", lambda *a, **k: ["dummy.nc"])
+    monkeypatch.setattr(gl.xr, "open_mfdataset", lambda *a, **k: fake_ds)
+
+    dataset_path = gl.GLORYS.get_glorys_data_from_rda(
+        ["2000-01-01", "2000-01-01"],
+        30,
+        31,
+        0.5,
+        -0.5,
+        tmp_path,
+        "temp.nc",
+        variables=["zos"],
+    )
+    result = xr.open_dataset(dataset_path)
+    out_lon = result.longitude.values
+
+    assert len(out_lon) == len(np.unique(out_lon))
+
+
 @pytest.mark.slow
 def test_get_glorys_data_from_rda(skip_if_not_glade, tmp_path):
     dates = ["2000-01-01", "2000-01-05"]

--- a/tests/raw_data_access/test_glorys.py
+++ b/tests/raw_data_access/test_glorys.py
@@ -37,8 +37,8 @@ def test_get_glorys_data_from_rda_antimeridian_wrap_no_mirror(tmp_path, monkeypa
         31,
         170,
         -170,
-        tmp_path,
-        "temp.nc",
+        output_folder=tmp_path,
+        output_filename="temp.nc",
         variables=["zos"],
     )
     result = xr.open_dataset(dataset_path)
@@ -93,8 +93,8 @@ def test_get_glorys_data_from_rda_lon_max_exactly_180_is_not_a_wrap(
         31,
         100,
         180,
-        tmp_path,
-        "temp.nc",
+        output_folder=tmp_path,
+        output_filename="temp.nc",
         variables=["zos"],
     )
     result = xr.open_dataset(dataset_path)
@@ -123,8 +123,8 @@ def test_get_glorys_data_from_rda_near_global_box_has_no_duplicate_longitudes(
         31,
         0.5,
         -0.5,
-        tmp_path,
-        "temp.nc",
+        output_folder=tmp_path,
+        output_filename="temp.nc",
         variables=["zos"],
     )
     result = xr.open_dataset(dataset_path)
@@ -141,7 +141,13 @@ def test_get_glorys_data_from_rda(skip_if_not_glade, tmp_path):
     lon_min = -71
     lon_max = -70
     dataset_path = gl.GLORYS.get_glorys_data_from_rda(
-        dates, lat_min, lat_max, lon_min, lon_max, tmp_path, "temp.nc"
+        dates,
+        lat_min,
+        lat_max,
+        lon_min,
+        lon_max,
+        output_folder=tmp_path,
+        output_filename="temp.nc",
     )
     dataset = xr.open_dataset(dataset_path)
     assert dataset.time.values[0] == np.datetime64("2000-01-01T12:00:00.000000000")


### PR DESCRIPTION
## Summary
Two related bugs in the OBC forcing pipeline, found while building pole-centered Arctic/Antarctic test domains for a location-dependent MOM6/CESM scaling comparison (any domain that fully encircles a pole necessarily has edges that cross the antimeridian and/or the prime meridian):

- **`extract_forcings/obc.py`**: `_regrid_boundary` sliced each `regrid_step`-sized chunk with `slice(chunk_start, chunk_end)`, where both bounds are midnight-anchored dates. Daily-mean products like GLORYS timestamp each day's value at noon, so the slice's upper bound excluded `chunk_end`'s own data point. This silently dropped the last day of every multi-day chunk, and produced a **fully empty selection** for a single-day trailing chunk (e.g. a date range that isn't an exact multiple of `regrid_step_days`), crashing downstream with a zero-size-array `IndexError`.
- **`raw_data_access/datasets/glorys.py`**: `get_glorys_data_from_rda` routed any opposite-sign `(lon_min, lon_max)` pair into its antimeridian-split-and-concat branch, but that's also true for a box straddling the prime meridian (e.g. `-45..45`), not just genuine antimeridian wraparound (e.g. `170..-170`). For the former, the two slices overlap heavily instead of being disjoint, **duplicating a large swath of longitude values** in the concatenated result — silently tolerated by `xesmf`'s regridder (`ignore_degenerate=True`) but not by `xarray`'s `interpolate_na` (used for initial-condition gap-filling), which crashed with "Index 'longitude' has duplicate values".

Also includes an incidental submodule pointer update for `rm6`, pointing at the fixed `regional-mom6` commit (degenerate-cell OBC regrid fix, see CROCODILE-CESM/regional-mom6#68).

## Test plan
- [x] Verified the exact `IndexError`/zero-size-chunk crash no longer occurs against real GLORYS raw data (before/after comparison of the chunk selection).
- [x] Verified the duplicate-longitude bug no longer occurs for both a prime-meridian-straddling box and the full-wraparound case (0 duplicates in both, previously ~50%).
- [x] Ran full Equatorial Pacific and Antarctic OBC+IC forcing pipelines end-to-end on Derecho with real GLORYS data; both now complete successfully where they previously crashed.
- [x] Built and ran CESM cases against the corrected forcings for both locations (clean runs, no FATAL/CFL/NaN errors, `read_cesm_timing` timing collected).