### PR TITLE
Add CESM_NOT_PORTED machine + optimize case creating tests (to not do that)

### DIFF
--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -33,6 +33,74 @@ from CrocoDash import case_state
 NOT_PORTED_MACHINE = "CESM_NOT_PORTED"
 
 
+# CESM's component classes, in the order they appear in a compset long name. Fixed by
+# the compset format itself, not by what a given checkout contains, which is why the
+# no-checkout path can hardcode them.
+COMP_CLASSES = ["ATM", "LND", "ICE", "OCN", "ROF", "GLC", "WAV"]
+
+
+class _NoCesmCIME:
+    """Stand-in for CIME_interface when there is no CESM checkout to read.
+
+    CIME_interface needs the tree: it asserts <cesmroot>/cime exists, reads CIME's
+    version, then parses component classes, models, physics, options, grids and compsets
+    out of the XML -- and only after all that does _retrieve_machines() decide whether the
+    host is ported. So "un-ported" cannot by itself mean "no checkout": the placeholder
+    machine substitutes five host-configuration fields, and nothing substitutes the model
+    catalogue.
+
+    What CrocoDash actually needs from that catalogue on a configure-only path is much
+    smaller than the catalogue itself, and this provides it:
+
+    - the component classes, which are fixed by the compset long-name format;
+    - splitting a compset long name into components, which is pure string work;
+    - the host-configuration fields, which are exactly what the placeholder supplies.
+
+    Everything else the catalogue is used for is *validation* -- checking a compset's
+    physics and options and a grid name against what this CESM can actually build. With no
+    checkout there is nothing to validate against, so Case skips that step and takes the
+    caller's compset long name and grid names at face value. The trade is real and
+    deliberate: a typo is no longer caught at configure time and will instead surface when
+    the case is created on a ported machine.
+
+    compsets is deliberately empty: alias resolution is the one thing that genuinely
+    cannot work without the catalogue, so a long name is required here.
+    """
+
+    machine = NOT_PORTED_MACHINE
+    machines = [NOT_PORTED_MACHINE]
+    project_required = {NOT_PORTED_MACHINE: False}
+    comp_classes = COMP_CLASSES
+    compsets = {}
+    # None rather than an empty dict: an empty catalogue would make every grid name look
+    # invalid, whereas the intent is that grid names simply go unchecked. Callers test
+    # `domains is not None` before validating against it.
+    domains = None
+
+    def __init__(self, cime_output_root=None, din_loc_root=None):
+        # Same defaults as CIME_interface._handle_machine_not_ported, but without
+        # creating them: nothing on this path writes to either.
+        self.cime_output_root = str(cime_output_root or Path.home() / "scratch")
+        self.din_loc_root = str(din_loc_root or Path.home() / "inputdata")
+
+    def get_components_from_compset_lname(self, compset_lname):
+        """Split a compset long name into {component class: physics}.
+
+        Mirrors CIME_interface.get_components_from_compset_lname, which is pure string
+        manipulation over comp_classes and needs no catalogue.
+        """
+        parts = compset_lname.split("_")
+        if len(parts) < len(self.comp_classes) + 1:
+            raise ValueError(
+                f"Invalid compset long name: {compset_lname!r}. Expected an init time "
+                f"followed by {len(self.comp_classes)} components "
+                f"({'_'.join(self.comp_classes)})."
+            )
+        return {
+            comp_class: parts[i + 1] for i, comp_class in enumerate(self.comp_classes)
+        }
+
+
 def _emulate_not_ported(cime):
     """Put an already-initialized CIME interface into the un-ported state, so that
     ``machine=CESM_NOT_PORTED`` can be requested on any host.
@@ -83,7 +151,7 @@ class Case:
     def __init__(
         self,
         *,
-        cesmroot: str | Path,
+        cesmroot: str | Path | None = None,
         caseroot: str | Path,
         inputdir: str | Path,
         compset: str,
@@ -105,8 +173,12 @@ class Case:
 
         Parameters
         ----------
-        cesmroot : str | Path
-            Path to the existing CESM root directory.
+        cesmroot : str | Path, optional
+            Path to an existing CESM root directory. If omitted, the case is configured
+            without CESM: machine is forced to CESM_NOT_PORTED, CIME is never invoked, and
+            the compset long name and grid names are accepted without validation (a CESM
+            checkout is what validation reads). A compset alias cannot be resolved in that
+            mode, so a long name is required. See _NoCesmCIME.
         caseroot : str | Path
             Path to the case root directory to be created.
         inputdir : str | Path
@@ -149,10 +221,34 @@ class Case:
             k: v for k, v in _locals.items() if k not in case_state.INIT_ARGS_EXCLUDE
         }
 
-        # Initialize visualCaseGen system and get the CIME interface
-        self.cime = initialize_visualCaseGen(cesmroot)
-        if machine == NOT_PORTED_MACHINE:
-            _emulate_not_ported(self.cime)
+        # An id for this construction, used to suffix the grid input filenames. Generated
+        # here rather than read back out of cvars["MB_ATTEMPT_ID"] so that it exists on
+        # the no-checkout path, where visualCaseGen is never initialized.
+        self.session_id = str(uuid.uuid1())[:6]
+
+        # Initialize visualCaseGen system and get the CIME interface. With no CESM
+        # checkout there is nothing for it to read, so stand in for it and skip the
+        # configuration pipeline entirely -- see _NoCesmCIME.
+        self.has_cesm = cesmroot is not None
+        if self.has_cesm:
+            self.cime = initialize_visualCaseGen(cesmroot)
+            if machine == NOT_PORTED_MACHINE:
+                _emulate_not_ported(self.cime)
+        else:
+            if machine not in (None, NOT_PORTED_MACHINE):
+                raise ValueError(
+                    f"machine={machine!r} was given without a cesmroot. Without a CESM "
+                    f"checkout only {NOT_PORTED_MACHINE} is possible, since CIME is what "
+                    "defines every other machine."
+                )
+            machine = NOT_PORTED_MACHINE
+            self.cime = _NoCesmCIME()
+            print(
+                "No cesmroot given: configuring without CESM. The compset long name and "
+                "grid names are taken as given and NOT validated, since validating them "
+                "is what needs the checkout. Forcing extraction is unaffected. Recreate "
+                "the case on a ported machine from crocodash_case.yaml."
+            )
 
         # Determine compset alias and long name
         if compset in self.cime.compsets:
@@ -183,7 +279,7 @@ class Case:
         )
 
         # Set instance attributes from arguments, in argument order
-        self.cesmroot = Path(cesmroot)
+        self.cesmroot = Path(cesmroot) if cesmroot is not None else None
         self.caseroot = Path(caseroot)
         self.inputdir = Path(inputdir)
         self.ocn_grid = ocn_grid
@@ -221,7 +317,8 @@ class Case:
         # Using visualCaseGen's configuration system, set the configuration variables for the case
         # based on the provided arguments. This includes setting the compset, grid, and launch variables.
         try:
-            self._configure_case(atm_grid_name, rof_grid_name)
+            if self.has_cesm:
+                self._configure_case(atm_grid_name, rof_grid_name)
         except Exception as e:
             print(f"\n{ERROR}Case Configuration Error:{RESET}")
             print(f"  {str(e)}")
@@ -234,19 +331,27 @@ class Case:
         # Having set the configuration variables and created the grid input files, we can now create the case instance.
         self._create_newcase()
 
+        # Resolved once here rather than re-asked at each call site: there is no
+        # CaseCreator without a checkout, and nothing to be non-local *to* when CIME is
+        # never invoked.
+        self.is_non_local = self.cc._is_non_local() if self.cc is not None else False
+
         # After creating the case, instantiate the CIME case object for later use. This
         # parses the case's env_*.xml files, which only exist once case.setup has run, so
         # there is nothing to attach to when the case was configured but not created.
         if self.do_exec:
             self._cime_case = self.cime.get_case(
-                self.caseroot, non_local=self.cc._is_non_local()
+                self.caseroot, non_local=self.is_non_local
             )
         else:
             self._cime_case = None
 
-        self.is_non_local = self.cc._is_non_local()
-
-        self._apply_final_xmlchanges(ntasks_ocn, job_queue, job_wallclock_time)
+        # visualCaseGen's xmlchange() reads cvars["CASEROOT"] before it consults do_exec,
+        # so it cannot even be called through to be skipped without a checkout. Nothing is
+        # lost: every value it sets is derived from an init arg, all of which are in the
+        # state file, so recreating the case on a ported machine applies them for real.
+        if self.has_cesm:
+            self._apply_final_xmlchanges(ntasks_ocn, job_queue, job_wallclock_time)
 
         self._write_state()
 
@@ -343,20 +448,31 @@ class Case:
         )
         if not isinstance(ocn_topo, Topo):
             raise TypeError("ocn_topo must be a Topo object.")
-        if atm_grid_name not in (available_atm_grids := cime.domains["atm"].keys()):
+        # The three cime.domains lookups below validate grid names against the CESM grid
+        # catalogue, which only exists when there is a checkout to read it from. With none,
+        # grid names are taken as given -- see _NoCesmCIME.
+        if cime.domains is not None and atm_grid_name not in (
+            available_atm_grids := cime.domains["atm"].keys()
+        ):
             raise ValueError(f"atm_grid_name must be one of {available_atm_grids}.")
         if rof_grid_name is not None:
             assert "SROF" not in compset_lname, (
                 "When a runoff grid is specified, "
                 "the compset must include an active or data runoff model."
             )
-            if rof_grid_name not in (available_rof_grids := cime.domains["rof"].keys()):
+            if cime.domains is not None and rof_grid_name not in (
+                available_rof_grids := cime.domains["rof"].keys()
+            ):
                 raise ValueError(f"rof_grid_name must be one of {available_rof_grids}.")
         if ocn_grid.name is None:
             raise ValueError(
                 "ocn_grid must have a name. Please set it using the 'name' attribute."
             )
-        if ocn_grid.name in cime.domains["ocnice"] and not override:
+        if (
+            cime.domains is not None
+            and ocn_grid.name in cime.domains["ocnice"]
+            and not override
+        ):
             raise ValueError(
                 f"ocn_grid name '{ocn_grid.name}' is already registered in CESM's grid config. "
                 "This happens when a previous case with this grid was deleted without using override=True. "
@@ -401,8 +517,7 @@ class Case:
         ocnice.mkdir()
 
         # suffix for the MOM6 grid files
-        session_id = cvars["MB_ATTEMPT_ID"].value
-        suffix = f"{ocn_grid.name}_{session_id}"
+        suffix = f"{ocn_grid.name}_{self.session_id}"
 
         # MOM6 supergrid file
         self.supergrid_path = str(ocnice / f"ocean_hgrid_{suffix}.nc")
@@ -443,8 +558,16 @@ class Case:
         if not self.caseroot.parent.exists():
             self.caseroot.parent.mkdir(parents=True, exist_ok=False)
 
-        self.cc = CaseCreator(
-            self.cime, allow_xml_override=self.override, add_grids_to_ccs_config=False
+        # CaseCreator drives CIME and reads visualCaseGen's cvars, neither of which
+        # exists without a checkout.
+        self.cc = (
+            CaseCreator(
+                self.cime,
+                allow_xml_override=self.override,
+                add_grids_to_ccs_config=False,
+            )
+            if self.has_cesm
+            else None
         )
 
         if not self.do_exec:
@@ -602,7 +725,6 @@ class Case:
             "function_args": function_args,
         }
 
-        self.session_id = cvars["MB_ATTEMPT_ID"].value
         self.grid_name = self.ocn_grid.name
 
         config_path = self.extract_forcings_path / "config.json"
@@ -612,24 +734,29 @@ class Case:
         self.fcr = ForcingConfigRegistry(self.compset_lname, inputs, self)
         self.fcr.run_configurators(config_path)
 
-        xmlchange(
-            "RUN_STARTDATE",
-            str(self.date_range[0])[:10],
-            do_exec=self.do_exec,
-            is_non_local=self.cc._is_non_local(),
-        )
-        xmlchange(
-            "STOP_OPTION",
-            "ndays",
-            do_exec=self.do_exec,
-            is_non_local=self.cc._is_non_local(),
-        )
-        xmlchange(
-            "STOP_N",
-            (self.date_range[1] - self.date_range[0]).days,
-            do_exec=self.do_exec,
-            is_non_local=self.cc._is_non_local(),
-        )
+        # As in _apply_final_xmlchanges, xmlchange() reads cvars["CASEROOT"] before it
+        # consults do_exec, so it cannot be called at all without a checkout. All three
+        # values derive from date_range, which the forcing config records, so recreating
+        # the case on a ported machine sets them for real.
+        if self.has_cesm:
+            xmlchange(
+                "RUN_STARTDATE",
+                str(self.date_range[0])[:10],
+                do_exec=self.do_exec,
+                is_non_local=self.is_non_local,
+            )
+            xmlchange(
+                "STOP_OPTION",
+                "ndays",
+                do_exec=self.do_exec,
+                is_non_local=self.is_non_local,
+            )
+            xmlchange(
+                "STOP_N",
+                (self.date_range[1] - self.date_range[0]).days,
+                do_exec=self.do_exec,
+                is_non_local=self.is_non_local,
+            )
         self._configure_forcings_called = True
 
     def process_forcings(self, **kwargs):
@@ -896,7 +1023,9 @@ class Case:
             self.ocn_grid.tlat.max().item() - self.ocn_grid.tlat.min().item()
         )
         cvars["CUSTOM_OCN_GRID_NAME"].value = self.ocn_grid.name
-        cvars["MB_ATTEMPT_ID"].value = str(uuid.uuid1())[:6]
+        # Mirror the id generated in __init__; CaseCreator names its ESMF mesh file
+        # from this cvar, so the two must agree.
+        cvars["MB_ATTEMPT_ID"].value = self.session_id
         cvars["MOM6_BATHY_STATUS"].value = "Complete"
         if Stage.active().title == "Custom Ocean Grid":
             Stage.active().proceed()
@@ -966,12 +1095,12 @@ class Case:
             {
                 # Derived / resolved fields that can't come from init args directly
                 "inputdir": str(self.inputdir),
-                "cesmroot": str(self.cesmroot),
+                "cesmroot": str(self.cesmroot) if self.cesmroot else None,
                 "supergrid_path": self.supergrid_path,
                 "topo_path": self.topo_path,
                 "vgrid_path": self.vgrid_path,
                 "grid_name": self.ocn_grid.name,
-                "session_id": cvars["MB_ATTEMPT_ID"].value,
+                "session_id": self.session_id,
                 "compset_lname": self.compset_lname,
                 "machine": self.machine,
                 # Scalar init args captured at construction time
@@ -989,16 +1118,16 @@ class Case:
             "MOM6_MEMORY_MODE",
             "dynamic_symmetric",
             do_exec=self.do_exec,
-            is_non_local=self.cc._is_non_local(),
+            is_non_local=self.is_non_local,
         )
 
-        # xmlchange("ROOTPE_OCN", 128, is_non_local=self.cc._is_non_local()) -> needs to be before the the setup
+        # xmlchange("ROOTPE_OCN", 128, is_non_local=self.is_non_local) -> needs to be before the the setup
         if ntasks_ocn is not None:
             xmlchange(
                 "NTASKS_OCN",
                 ntasks_ocn,
                 do_exec=self.do_exec,
-                is_non_local=self.cc._is_non_local(),
+                is_non_local=self.is_non_local,
             )
         # This will trigger for both the run and the archiver.
         if job_queue is not None:
@@ -1006,14 +1135,14 @@ class Case:
                 "JOB_QUEUE",
                 job_queue,
                 do_exec=self.do_exec,
-                is_non_local=self.cc._is_non_local(),
+                is_non_local=self.is_non_local,
             )
         if job_wallclock_time is not None:
             xmlchange(
                 "JOB_WALLCLOCK_TIME",
                 job_wallclock_time,
                 do_exec=self.do_exec,
-                is_non_local=self.cc._is_non_local(),
+                is_non_local=self.is_non_local,
             )
 
     def validate_case(self):

--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -57,6 +57,7 @@ class Case:
         ntasks_ocn: int | None = None,
         job_queue: str | None = None,
         job_wallclock_time: str | None = None,
+        do_exec: bool = True,
     ):
         """
         Initialize a new regional MOM6 case within the CESM framework.
@@ -99,6 +100,14 @@ class Case:
             The queue to submit the CESM case to. If None, defaults to the CESM defaults (usually main)
         job_wallclock_time: str, optional
             Must be in the form hh:mm:ss. If None, defaults to the CESM defaults
+        do_exec : bool, optional
+            Whether to actually run the CIME commands that create and modify the case
+            (create_newcase, case.setup, xmlchange, user_nl appends). Default is True.
+            Pass False to configure the case without executing any of them: the grid
+            input files, the state file, and the forcing configuration are all still
+            written, so the case can be recreated later on a ported machine from
+            crocodash_case.yaml. This is forced to False on an un-ported machine
+            (MACHINE == CESM_NOT_PORTED), where CIME cannot create a case at all.
         """
 
         # Capture scalar init args for state serialization before any local vars are added.
@@ -156,7 +165,11 @@ class Case:
         # Forcing extraction is unaffected -- it never touches CIME -- so the expensive
         # download+regrid work still runs, and the case itself is recreated later on a
         # ported machine from crocodash_case.yaml.
-        self.do_exec = self.machine != NOT_PORTED_MACHINE
+        # do_exec=False additionally lets a caller opt into the same configure-only
+        # behaviour on a ported machine, where NOT_PORTED_MACHINE is never selected:
+        # everything except the CIME shell-outs still happens, which is how the test
+        # suite avoids paying for create_newcase/case.setup in every fixture.
+        self.do_exec = do_exec and self.machine != NOT_PORTED_MACHINE
         self.project = project
         self.override = override
         self.ntasks_ocn = ntasks_ocn
@@ -402,14 +415,19 @@ class Case:
         )
 
         if not self.do_exec:
-            # CaseCreator refuses to create a case for the placeholder machine, so there
-            # is nothing to run here. Everything downstream (state file, user_nl writes,
+            # Either CaseCreator refuses to create a case for the placeholder machine, or
+            # the caller asked for configuration without execution. Either way there is
+            # nothing to run here. Everything downstream (state file, user_nl writes,
             # forcing config) still expects the directory to exist, and create_newcase is
             # what would normally have made it.
             self.caseroot.mkdir(parents=True, exist_ok=self.override)
+            reason = (
+                f"Machine is {NOT_PORTED_MACHINE}"
+                if self.machine == NOT_PORTED_MACHINE
+                else "do_exec is False"
+            )
             print(
-                f"Machine is {NOT_PORTED_MACHINE}: configuring "
-                f"{self.caseroot} without creating a CESM case."
+                f"{reason}: configuring {self.caseroot} without creating a CESM case."
             )
             return
 
@@ -641,6 +659,23 @@ class Case:
         return self.caseroot.name
 
     @property
+    def _run_dir(self) -> Path:
+        """The case's CIME run directory.
+
+        Normally read straight off the CIME case object. When the case was configured
+        but never created (``do_exec=False``) there is no case object to ask, so fall
+        back to the path CIME would have derived, ``$CIME_OUTPUT_ROOT/$CASE/run``.
+        """
+        if self._cime_case is not None:
+            return Path(self._cime_case.get_value("RUNDIR"))
+        # rm6's experiment mkdirs mom_run_dir without parents, and nothing has created
+        # $CIME_OUTPUT_ROOT/$CASE yet (case.setup is what normally would), so make the
+        # whole chain here.
+        run_dir = Path(self.cime.cime_output_root) / self.caseroot.name / "run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    @property
     def expt(self) -> rmom6.experiment:
 
         if not hasattr(self, "date_range"):
@@ -667,7 +702,7 @@ class Case:
             number_vertical_layers=None,
             layer_thickness_ratio=None,
             depth=self.ocn_topo.max_depth,
-            mom_run_dir=self._cime_case.get_value("RUNDIR"),
+            mom_run_dir=self._run_dir,
             mom_input_dir=self.inputdir / "ocnice",
             hgrid_type=self.ocn_grid,
             vgrid_type=self.ocn_vgrid,

--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -26,6 +26,12 @@ from CrocoDash.forcing.driver import run_workflow
 
 from CrocoDash import case_state
 
+# visualCaseGen's placeholder machine name, set when CESM has no machine definition for
+# the current host (see cime_interface._handle_machine_not_ported). Case creation is
+# disabled for it, so CrocoDash configures without executing. Keep in sync with
+# visualCaseGen.
+NOT_PORTED_MACHINE = "CESM_NOT_PORTED"
+
 
 class Case:
     """This class represents a regional MOM6 case within the CESM framework. It is similar to the
@@ -143,6 +149,14 @@ class Case:
         self.rof_grid_name = rof_grid_name
         self.ninst = ninst
         self.machine = machine or self.cime.machine
+        # CESM_NOT_PORTED is visualCaseGen's placeholder machine, used when CESM has no
+        # machine definition for the current host (e.g. a laptop with a CESM checkout but
+        # no port). CIME cannot create or set up a case there, so everything that would
+        # shell out to create_newcase/case.setup/xmlchange is configured but not executed.
+        # Forcing extraction is unaffected -- it never touches CIME -- so the expensive
+        # download+regrid work still runs, and the case itself is recreated later on a
+        # ported machine from crocodash_case.yaml.
+        self.do_exec = self.machine != NOT_PORTED_MACHINE
         self.project = project
         self.override = override
         self.ntasks_ocn = ntasks_ocn
@@ -174,10 +188,15 @@ class Case:
         # Having set the configuration variables and created the grid input files, we can now create the case instance.
         self._create_newcase()
 
-        # After creating the case, instantiate the CIME case object for later use.
-        self._cime_case = self.cime.get_case(
-            self.caseroot, non_local=self.cc._is_non_local()
-        )
+        # After creating the case, instantiate the CIME case object for later use. This
+        # parses the case's env_*.xml files, which only exist once case.setup has run, so
+        # there is nothing to attach to when the case was configured but not created.
+        if self.do_exec:
+            self._cime_case = self.cime.get_case(
+                self.caseroot, non_local=self.cc._is_non_local()
+            )
+        else:
+            self._cime_case = None
 
         self.is_non_local = self.cc._is_non_local()
 
@@ -382,11 +401,27 @@ class Case:
             self.cime, allow_xml_override=self.override, add_grids_to_ccs_config=False
         )
 
+        if not self.do_exec:
+            # CaseCreator refuses to create a case for the placeholder machine, so there
+            # is nothing to run here. Everything downstream (state file, user_nl writes,
+            # forcing config) still expects the directory to exist, and create_newcase is
+            # what would normally have made it.
+            self.caseroot.mkdir(parents=True, exist_ok=self.override)
+            print(
+                f"Machine is {NOT_PORTED_MACHINE}: configuring "
+                f"{self.caseroot} without creating a CESM case."
+            )
+            return
+
         try:
             self.cc.create_case(do_exec=True)
-        except Exception as e:
-            print(f"{ERROR}{str(e)}{RESET}")
+        except Exception:
+            # Revert the ccs_config edits, then re-raise: a half-created case looks
+            # identical to a working one until something much later fails on a file
+            # case.setup never wrote (e.g. a missing user_nl_cpl surfacing inside
+            # CaseBundle), so failing here is far cheaper to diagnose.
             self.cc.revert_launch(do_exec=True)
+            raise
 
     def configure_forcings(
         self,
@@ -533,16 +568,19 @@ class Case:
         xmlchange(
             "RUN_STARTDATE",
             str(self.date_range[0])[:10],
+            do_exec=self.do_exec,
             is_non_local=self.cc._is_non_local(),
         )
         xmlchange(
             "STOP_OPTION",
             "ndays",
+            do_exec=self.do_exec,
             is_non_local=self.cc._is_non_local(),
         )
         xmlchange(
             "STOP_N",
             (self.date_range[1] - self.date_range[0]).days,
+            do_exec=self.do_exec,
             is_non_local=self.cc._is_non_local(),
         )
         self._configure_forcings_called = True
@@ -886,19 +924,31 @@ class Case:
         xmlchange(
             "MOM6_MEMORY_MODE",
             "dynamic_symmetric",
+            do_exec=self.do_exec,
             is_non_local=self.cc._is_non_local(),
         )
 
         # xmlchange("ROOTPE_OCN", 128, is_non_local=self.cc._is_non_local()) -> needs to be before the the setup
         if ntasks_ocn is not None:
-            xmlchange("NTASKS_OCN", ntasks_ocn, is_non_local=self.cc._is_non_local())
+            xmlchange(
+                "NTASKS_OCN",
+                ntasks_ocn,
+                do_exec=self.do_exec,
+                is_non_local=self.cc._is_non_local(),
+            )
         # This will trigger for both the run and the archiver.
         if job_queue is not None:
-            xmlchange("JOB_QUEUE", job_queue, is_non_local=self.cc._is_non_local())
+            xmlchange(
+                "JOB_QUEUE",
+                job_queue,
+                do_exec=self.do_exec,
+                is_non_local=self.cc._is_non_local(),
+            )
         if job_wallclock_time is not None:
             xmlchange(
                 "JOB_WALLCLOCK_TIME",
                 job_wallclock_time,
+                do_exec=self.do_exec,
                 is_non_local=self.cc._is_non_local(),
             )
 

--- a/CrocoDash/case.py
+++ b/CrocoDash/case.py
@@ -33,6 +33,48 @@ from CrocoDash import case_state
 NOT_PORTED_MACHINE = "CESM_NOT_PORTED"
 
 
+def _emulate_not_ported(cime):
+    """Put an already-initialized CIME interface into the un-ported state, so that
+    ``machine=CESM_NOT_PORTED`` can be requested on any host.
+
+    CESM_NOT_PORTED is visualCaseGen's own placeholder rather than a CIME machine:
+    CIME_interface picks it in ``_handle_machine_not_ported()`` when CIME cannot identify
+    the host, and from then on it is the only machine the interface offers. Selecting it
+    on a host CESM *is* ported to therefore has to reproduce that state, or the request is
+    only half-applied. Two things go wrong otherwise, both verified: MACHINE's options
+    still come from the real machine list, so the assignment in ``_configure_launch``
+    fails with "CESM_NOT_PORTED not an option for MACHINE"; and ``_is_non_local()``
+    compares the interface's real machine against the selected one, so it would wrongly
+    report a non-local case and add ``--non-local`` to every xmlchange.
+
+    This mirrors the identity fields ``_handle_machine_not_ported()`` sets, but
+    deliberately leaves ``cime_output_root``/``din_loc_root`` pointing at the real host's
+    values. That handler falls back to ``~/scratch`` and ``~/inputdata`` and creates them,
+    which is right on a laptop with nothing better to use, but here the host's own roots
+    already exist and are the correct place to write -- and a test suite should not be
+    creating directories in ``$HOME`` as a side effect. What is being overridden is the
+    machine's *identity*, not the filesystem layout.
+    """
+    if cime.machine == NOT_PORTED_MACHINE:
+        return  # genuinely un-ported host; the interface is already in this state
+    # Asking for it on a host that *is* ported is deliberate, but it used to be rejected
+    # by init_args_check, and crocodash_case.yaml records the machine it was configured
+    # with -- so replaying an un-ported case's yaml here would otherwise quietly produce
+    # another case CIME never ran, where it previously raised. Say so.
+    print(
+        f"{NOT_PORTED_MACHINE} requested on {cime.machine}, which CESM *is* ported to: "
+        "the case will be configured but CIME will not be invoked, so no CESM case is "
+        f"created. Pass machine='{cime.machine}' (or another ported machine) for a real "
+        "case."
+    )
+    cime.machine = NOT_PORTED_MACHINE
+    cime.machines = [NOT_PORTED_MACHINE]
+    cime.project_required = {NOT_PORTED_MACHINE: False}
+    # MACHINE's options were derived from the real machine list by set_launcher_options()
+    # during initialize(); re-derive them from the now un-ported interface.
+    cvars["MACHINE"].options = cime.machines
+
+
 class Case:
     """This class represents a regional MOM6 case within the CESM framework. It is similar to the
     Experiment class in the regional_mom6 package, but with modifications to work within the CESM framework.
@@ -57,7 +99,6 @@ class Case:
         ntasks_ocn: int | None = None,
         job_queue: str | None = None,
         job_wallclock_time: str | None = None,
-        do_exec: bool = True,
     ):
         """
         Initialize a new regional MOM6 case within the CESM framework.
@@ -100,14 +141,6 @@ class Case:
             The queue to submit the CESM case to. If None, defaults to the CESM defaults (usually main)
         job_wallclock_time: str, optional
             Must be in the form hh:mm:ss. If None, defaults to the CESM defaults
-        do_exec : bool, optional
-            Whether to actually run the CIME commands that create and modify the case
-            (create_newcase, case.setup, xmlchange, user_nl appends). Default is True.
-            Pass False to configure the case without executing any of them: the grid
-            input files, the state file, and the forcing configuration are all still
-            written, so the case can be recreated later on a ported machine from
-            crocodash_case.yaml. This is forced to False on an un-ported machine
-            (MACHINE == CESM_NOT_PORTED), where CIME cannot create a case at all.
         """
 
         # Capture scalar init args for state serialization before any local vars are added.
@@ -118,6 +151,8 @@ class Case:
 
         # Initialize visualCaseGen system and get the CIME interface
         self.cime = initialize_visualCaseGen(cesmroot)
+        if machine == NOT_PORTED_MACHINE:
+            _emulate_not_ported(self.cime)
 
         # Determine compset alias and long name
         if compset in self.cime.compsets:
@@ -165,11 +200,9 @@ class Case:
         # Forcing extraction is unaffected -- it never touches CIME -- so the expensive
         # download+regrid work still runs, and the case itself is recreated later on a
         # ported machine from crocodash_case.yaml.
-        # do_exec=False additionally lets a caller opt into the same configure-only
-        # behaviour on a ported machine, where NOT_PORTED_MACHINE is never selected:
-        # everything except the CIME shell-outs still happens, which is how the test
-        # suite avoids paying for create_newcase/case.setup in every fixture.
-        self.do_exec = do_exec and self.machine != NOT_PORTED_MACHINE
+        # Requesting it explicitly is how the test suite avoids paying for
+        # create_newcase/case.setup in every fixture (see _emulate_not_ported).
+        self.do_exec = self.machine != NOT_PORTED_MACHINE
         self.project = project
         self.override = override
         self.ntasks_ocn = ntasks_ocn
@@ -421,13 +454,9 @@ class Case:
             # forcing config) still expects the directory to exist, and create_newcase is
             # what would normally have made it.
             self.caseroot.mkdir(parents=True, exist_ok=self.override)
-            reason = (
-                f"Machine is {NOT_PORTED_MACHINE}"
-                if self.machine == NOT_PORTED_MACHINE
-                else "do_exec is False"
-            )
             print(
-                f"{reason}: configuring {self.caseroot} without creating a CESM case."
+                f"Machine is {NOT_PORTED_MACHINE}: configuring {self.caseroot} "
+                "without creating a CESM case."
             )
             return
 
@@ -663,7 +692,7 @@ class Case:
         """The case's CIME run directory.
 
         Normally read straight off the CIME case object. When the case was configured
-        but never created (``do_exec=False``) there is no case object to ask, so fall
+        but never created (an un-ported machine) there is no case object to ask, so fall
         back to the path CIME would have derived, ``$CIME_OUTPUT_ROOT/$CASE/run``.
         """
         if self._cime_case is not None:

--- a/CrocoDash/case_state.py
+++ b/CrocoDash/case_state.py
@@ -41,7 +41,6 @@ INIT_ARGS_EXCLUDE = frozenset(
         "caseroot",
         "inputdir",
         "override",
-        "do_exec",
     }
 )
 

--- a/CrocoDash/case_state.py
+++ b/CrocoDash/case_state.py
@@ -41,6 +41,7 @@ INIT_ARGS_EXCLUDE = frozenset(
         "caseroot",
         "inputdir",
         "override",
+        "do_exec",
     }
 )
 

--- a/CrocoDash/forcing/base.py
+++ b/CrocoDash/forcing/base.py
@@ -389,9 +389,11 @@ class UserNLConfigParam(OutputParam):
         user_nl_name: str = "mom",
         comment: Optional[str] = None,
         is_file: bool = False,
+        do_exec: bool = True,
     ):
         super().__init__(name, comment, is_file=is_file)
         self.user_nl_name = user_nl_name
+        self.do_exec = do_exec
 
     def apply(self):
         if self.value is None:
@@ -401,7 +403,7 @@ class UserNLConfigParam(OutputParam):
         append_user_nl(
             self.user_nl_name,
             param,
-            do_exec=True,
+            do_exec=self.do_exec,
             comment=self.comment,
         )
         self.executed = True
@@ -438,9 +440,11 @@ class XMLConfigParam(OutputParam):
         is_non_local: bool = False,
         comment: Optional[str] = None,
         is_file: bool = False,
+        do_exec: bool = True,
     ):
         super().__init__(name, comment, is_file=is_file)
         self.is_non_local = is_non_local
+        self.do_exec = do_exec
 
     def apply(self):
         if self.value is None:
@@ -449,6 +453,7 @@ class XMLConfigParam(OutputParam):
         xmlchange(
             self.name,
             str(self.value),
+            do_exec=self.do_exec,
             is_non_local=self.is_non_local,
         )
         self.executed = True
@@ -605,12 +610,31 @@ class BaseConfigurator(ABC):
         case = getattr(self.registry, "case", None)
         return bool(getattr(case, "is_non_local", False))
 
+    @property
+    def do_exec(self) -> bool:
+        """Whether case-side effects should actually be executed.
+
+        False when the case was configured but never created (an un-ported machine,
+        i.e. MACHINE == CESM_NOT_PORTED), where there is no case directory to
+        xmlchange or append user_nl into. Sourced from the live Case via the
+        registry, the same way `is_non_local` is, so no configurator has to declare
+        a ctor arg just to carry it down to `apply()`.
+
+        Defaults to True -- the opposite of `is_non_local` -- so that a
+        configurator with no live Case (direct construction in tests, or
+        deserialize()) keeps behaving exactly as it did before this existed.
+        """
+        case = getattr(self.registry, "case", None)
+        return bool(getattr(case, "do_exec", True))
+
     @abstractmethod
     def configure(self):
         """Bind input values to parameters and files."""
         for p in self.output_params:
             if isinstance(p, XMLConfigParam):
                 p.is_non_local = self.is_non_local
+            if isinstance(p, (XMLConfigParam, UserNLConfigParam)):
+                p.do_exec = self.do_exec
             p.apply()
         pass
 

--- a/CrocoDash/forcing/base.py
+++ b/CrocoDash/forcing/base.py
@@ -627,6 +627,25 @@ class BaseConfigurator(ABC):
         case = getattr(self.registry, "case", None)
         return bool(getattr(case, "do_exec", True))
 
+    @property
+    def has_cesm(self) -> bool:
+        """Whether there is a CESM checkout behind this case.
+
+        With none, visualCaseGen is never initialized, so `cvars` is empty -- and both
+        `xmlchange` and `append_user_nl` read `cvars["CASEROOT"]` *before* they consult
+        `do_exec`, so they raise KeyError rather than no-op. Output params therefore have
+        to be skipped outright rather than applied with `do_exec=False`.
+
+        This is deliberately narrower than `do_exec`: on an un-ported machine that *does*
+        have a checkout, `apply()` is still called so that it prints the commands a user
+        would run to create the case by hand, which is the point of that path.
+
+        Defaults to True, like `do_exec`, so a configurator with no live Case (direct
+        construction in tests, or deserialize()) behaves as it always has.
+        """
+        case = getattr(self.registry, "case", None)
+        return bool(getattr(case, "has_cesm", True))
+
     @abstractmethod
     def configure(self):
         """Bind input values to parameters and files."""
@@ -635,6 +654,10 @@ class BaseConfigurator(ABC):
                 p.is_non_local = self.is_non_local
             if isinstance(p, (XMLConfigParam, UserNLConfigParam)):
                 p.do_exec = self.do_exec
+                if not self.has_cesm:
+                    # Nothing to write into, and the values are recorded in
+                    # crocodash_case.yaml for the eventual replay on a ported machine.
+                    continue
             p.apply()
         pass
 

--- a/CrocoDash/forcing/mom6.py
+++ b/CrocoDash/forcing/mom6.py
@@ -558,18 +558,19 @@ class ConditionsConfigurator(BaseConfigurator):
             )
 
         # This configurator batches its own writes rather than going through
-        # BaseConfigurator.configure()'s per-param loop, so it has to honor do_exec
-        # itself (see BaseConfigurator.do_exec).
-        append_user_nl(
-            "mom", ic_params, do_exec=self.do_exec, comment="Initial conditions"
-        )
-        append_user_nl(
-            "mom",
-            obc_params,
-            do_exec=self.do_exec,
-            comment="Open boundary conditions",
-            log_title=False,
-        )
+        # BaseConfigurator.configure()'s per-param loop, so it has to honor do_exec --
+        # and has_cesm -- itself (see BaseConfigurator.do_exec / .has_cesm).
+        if self.has_cesm:
+            append_user_nl(
+                "mom", ic_params, do_exec=self.do_exec, comment="Initial conditions"
+            )
+            append_user_nl(
+                "mom",
+                obc_params,
+                do_exec=self.do_exec,
+                comment="Open boundary conditions",
+                log_title=False,
+            )
         for param in self.output_params:
             if isinstance(param, UserNLConfigParam):
                 param.executed = True

--- a/CrocoDash/forcing/mom6.py
+++ b/CrocoDash/forcing/mom6.py
@@ -557,11 +557,16 @@ class ConditionsConfigurator(BaseConfigurator):
                 (param.name, param.value)
             )
 
-        append_user_nl("mom", ic_params, do_exec=True, comment="Initial conditions")
+        # This configurator batches its own writes rather than going through
+        # BaseConfigurator.configure()'s per-param loop, so it has to honor do_exec
+        # itself (see BaseConfigurator.do_exec).
+        append_user_nl(
+            "mom", ic_params, do_exec=self.do_exec, comment="Initial conditions"
+        )
         append_user_nl(
             "mom",
             obc_params,
-            do_exec=True,
+            do_exec=self.do_exec,
             comment="Open boundary conditions",
             log_title=False,
         )

--- a/tests/fixtures/objects.py
+++ b/tests/fixtures/objects.py
@@ -1,8 +1,24 @@
+import os
 import pytest
+import shutil
 from CrocoDash.rm6 import regional_mom6 as rm6
 from CrocoDash.case import Case
 from pathlib import Path
 from uuid import uuid4
+
+# Forcing configuration shared by ported_case and the fast fixtures that stand in for
+# it. Kept in one place so a copy of the ported case and a freshly configured fast case
+# describe the same experiment, and a test can move between them without its
+# assertions changing.
+FORCING_ARGS = {
+    "date_range": ["2020-01-01 00:00:00", "2020-02-01 00:00:00"],
+    "boundaries": ["north", "east"],
+    # Tides are configured here so that a copy of the ported case satisfies the tests
+    # that assert on a tidal forcing configuration, without needing a case of its own.
+    "tidal_constituents": ["M2"],
+    "tpxo_elevation_filepath": "s3://crocodile-cesm/CrocoDash/data/tpxo/h_tpxo9.v1.zarr/",
+    "tpxo_velocity_filepath": "s3://crocodile-cesm/CrocoDash/data/tpxo/u_tpxo9.v1.zarr/",
+}
 
 
 @pytest.fixture(scope="session")
@@ -28,33 +44,111 @@ def setup_sample_rm6_expt(tmp_path):
 
 @pytest.fixture(scope="session")
 def get_case_with_cf(CrocoDash_case_factory, tmp_path_factory):
+    """A configured (not created) case with forcings. See CrocoDash_case_factory."""
     case = CrocoDash_case_factory(tmp_path_factory.mktemp(f"case-{uuid4().hex}"))
-    case.configure_forcings(
-        date_range=["2020-01-01 00:00:00", "2020-02-01 00:00:00"],
-        boundaries=["north", "east"],
-    )
-    return case
-
-
-@pytest.fixture(scope="session")
-def get_shareable_CrocoDash_case(CrocoDash_case_factory, tmp_path_factory):
-    case = CrocoDash_case_factory(tmp_path_factory.mktemp(f"case-{uuid4().hex}"))
-    case.configure_forcings(
-        date_range=["2020-01-01 00:00:00", "2020-01-09 00:00:00"],
-        tidal_constituents=["M2"],
-        tpxo_elevation_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/h_tpxo9.v1.zarr/",
-        tpxo_velocity_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/u_tpxo9.v1.zarr/",
-    )
+    case.configure_forcings(**FORCING_ARGS)
     return case
 
 
 @pytest.fixture(scope="session")
 def get_CrocoDash_case(CrocoDash_case_factory, tmp_path_factory):
+    """A configured (not created) case with no forcings. See CrocoDash_case_factory."""
+    return CrocoDash_case_factory(tmp_path_factory.mktemp(f"case-{uuid4().hex}"))
 
-    # Set some defaults
-    caseroot = tmp_path_factory.mktemp(f"case-{uuid4().hex}")
 
-    return CrocoDash_case_factory(caseroot)
+@pytest.fixture
+def get_mutable_CrocoDash_case(CrocoDash_case_factory, tmp_path):
+    """A configured (not created) case a single test may mutate freely.
+
+    Function-scoped, unlike the session-scoped fixtures above: for tests that call
+    configure_forcings() themselves, which rewrites case state and wipes the
+    extract_forcings directory, so sharing one across tests makes them order-dependent.
+    """
+    return CrocoDash_case_factory(tmp_path / f"case-{uuid4().hex}")
+
+
+@pytest.fixture(scope="session")
+def ported_case(CrocoDash_case_factory, tmp_path_factory):
+    """The one case in the suite that really runs CIME.
+
+    create_newcase plus case.setup dominates the cost of building a case (seconds
+    each, against a small fraction of that for everything else Case.__init__ does), so
+    every other fixture here configures its case without executing CIME
+    (do_exec=False) and anything that needs the artifacts only CIME writes -- the
+    xmlquery/xmlchange scripts, env_*.xml, the default user_nl files, SourceMods/,
+    README.case -- shares this one instead of paying for its own.
+
+    Treat it as read-only: a test that mutates the caseroot, or writes into the
+    inputdir, must take a copy via ported_case_copy instead.
+    """
+    case = CrocoDash_case_factory(tmp_path_factory.mktemp("ported-case"), do_exec=True)
+    case.configure_forcings(**FORCING_ARGS)
+    return case
+
+
+def _rewrite_paths(root, replacements):
+    """Substitute absolute paths inside the text files of a copied case.
+
+    A copied case still names the original everywhere the original wrote its own path,
+    and those references are load-bearing rather than cosmetic:
+
+    - CIME resolves ./xmlchange's replay log against CASEROOT in env_case.xml, so an
+      xmlchange in an unrewritten copy appends to the *original* case's replay.sh --
+      the copy never records it, and the case every other test reads gets polluted.
+    - CaseBundle.bundle() locates the ocnice directory from user_nl_mom's INPUTDIR
+      line, so a copy given its own inputdir would still bundle the original's files.
+
+    Symlinks are skipped and symlinked directories are never descended into: a
+    caseroot's ./xmlquery and Tools/ point into CESM itself, and writing through them
+    would edit the CESM installation.
+    """
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if not Path(dirpath, d).is_symlink()]
+        for filename in filenames:
+            path = Path(dirpath, filename)
+            if path.is_symlink():
+                continue
+            try:
+                text = path.read_text()
+            except (UnicodeDecodeError, OSError):
+                continue  # binary (or unreadable) file, nothing to rewrite
+            rewritten = text
+            for old, new in replacements:
+                rewritten = rewritten.replace(str(old), str(new))
+            if rewritten != text:
+                path.write_text(rewritten)
+
+
+@pytest.fixture
+def ported_case_copy(ported_case, tmp_path_factory):
+    """Factory for throwaway copies of ported_case, returning the copied caseroot.
+
+    A copied caseroot stays a working CIME case -- ./xmlquery and ./xmlchange
+    --non-local read and write the copy's own env_*.xml -- so a mutating test gets full
+    isolation for the price of a directory copy rather than a second create_newcase,
+    once the paths the original baked into itself are rewritten (see _rewrite_paths).
+
+    Pass with_inputdir=True when the test also writes into the case's inputdir, so
+    those writes don't land in the inputdir every other ported_case test reads.
+    """
+
+    def _copy(name="copy", with_inputdir=False):
+        root = tmp_path_factory.mktemp(f"ported-copy-{name}")
+        caseroot = root / "case"
+        shutil.copytree(ported_case.caseroot, caseroot, symlinks=True)
+        replacements = [(ported_case.caseroot, caseroot)]
+        if with_inputdir:
+            inputdir = root / "inputdir"
+            # symlinks=True: ocnice/rundir links into the case's run directory, which
+            # links back to inputdir, so following symlinks recurses forever.
+            shutil.copytree(ported_case.inputdir, inputdir, symlinks=True)
+            replacements.append((ported_case.inputdir, inputdir))
+            # Only extract_forcings holds paths; the rest of inputdir is NetCDF.
+            _rewrite_paths(inputdir / "extract_forcings", replacements)
+        _rewrite_paths(caseroot, replacements)
+        return caseroot
+
+    return _copy
 
 
 @pytest.fixture(scope="session")
@@ -74,13 +168,22 @@ def CrocoDash_case_factory(
         configure_forcings=False,
         compset: str = "1850_DATM%JRA_SLND_SICE_MOM6_SROF_SGLC_SWAV",
         atm_grid_name: str = "TL319",
+        do_exec: bool = False,
     ):
         """
         Factory function to create a CrocoDash Case object with sensible defaults.
         Can be called from pytest fixtures or standalone scripts.
+
+        do_exec defaults to False, so the case is configured but CIME is never invoked:
+        no create_newcase, no case.setup, no xmlchange, no user_nl writes. Grid input
+        files, the state file, and the forcing configuration are all still produced,
+        which is everything most tests actually assert on, and it is roughly an order
+        of magnitude faster. Pass do_exec=True only for a case that must carry real
+        CIME artifacts -- and prefer the ported_case fixture, which already provides
+        one, over creating another.
         """
         directory = Path(directory)
-        directory.mkdir(exist_ok=True)
+        directory.mkdir(parents=True, exist_ok=True)
         # Set Grid Info
         grid, topo, vgrid = gen_grid_topo_vgrid
 
@@ -110,6 +213,7 @@ def CrocoDash_case_factory(
             machine=machine,
             atm_grid_name=atm_grid_name,
             ninst=ninst,
+            do_exec=do_exec,
         )
         if configure_forcings:
             case.configure_forcings(

--- a/tests/fixtures/objects.py
+++ b/tests/fixtures/objects.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import shutil
 from CrocoDash.rm6 import regional_mom6 as rm6
-from CrocoDash.case import Case
+from CrocoDash.case import Case, NOT_PORTED_MACHINE
 from pathlib import Path
 from uuid import uuid4
 
@@ -74,14 +74,14 @@ def ported_case(CrocoDash_case_factory, tmp_path_factory):
     create_newcase plus case.setup dominates the cost of building a case (seconds
     each, against a small fraction of that for everything else Case.__init__ does), so
     every other fixture here configures its case without executing CIME
-    (do_exec=False) and anything that needs the artifacts only CIME writes -- the
+    (CESM_NOT_PORTED) and anything that needs the artifacts only CIME writes -- the
     xmlquery/xmlchange scripts, env_*.xml, the default user_nl files, SourceMods/,
     README.case -- shares this one instead of paying for its own.
 
     Treat it as read-only: a test that mutates the caseroot, or writes into the
     inputdir, must take a copy via ported_case_copy instead.
     """
-    case = CrocoDash_case_factory(tmp_path_factory.mktemp("ported-case"), do_exec=True)
+    case = CrocoDash_case_factory(tmp_path_factory.mktemp("ported-case"), ported=True)
     case.configure_forcings(**FORCING_ARGS)
     return case
 
@@ -168,19 +168,20 @@ def CrocoDash_case_factory(
         configure_forcings=False,
         compset: str = "1850_DATM%JRA_SLND_SICE_MOM6_SROF_SGLC_SWAV",
         atm_grid_name: str = "TL319",
-        do_exec: bool = False,
+        ported: bool = False,
     ):
         """
         Factory function to create a CrocoDash Case object with sensible defaults.
         Can be called from pytest fixtures or standalone scripts.
 
-        do_exec defaults to False, so the case is configured but CIME is never invoked:
-        no create_newcase, no case.setup, no xmlchange, no user_nl writes. Grid input
-        files, the state file, and the forcing configuration are all still produced,
-        which is everything most tests actually assert on, and it is roughly an order
-        of magnitude faster. Pass do_exec=True only for a case that must carry real
-        CIME artifacts -- and prefer the ported_case fixture, which already provides
-        one, over creating another.
+        ported defaults to False, which selects CESM_NOT_PORTED -- visualCaseGen's
+        placeholder for a host CESM has no machine definition for. CIME cannot create a
+        case there, so no create_newcase, no case.setup, no xmlchange, no user_nl writes.
+        Grid input files, the state file, and the forcing configuration are all still
+        produced, which is everything most tests actually assert on, and it is roughly an
+        order of magnitude faster. Pass ported=True only for a case that must carry real
+        CIME artifacts -- and prefer the ported_case fixture, which already provides one,
+        over creating another.
         """
         directory = Path(directory)
         directory.mkdir(parents=True, exist_ok=True)
@@ -192,7 +193,9 @@ def CrocoDash_case_factory(
         inputdir = directory / "inputdir"
 
         # Decide machine
-        if is_github_actions:
+        if not ported:
+            machine = NOT_PORTED_MACHINE
+        elif is_github_actions:
             machine = "ubuntu-latest"
         elif is_glade_file_system:
             machine = "derecho"
@@ -213,7 +216,6 @@ def CrocoDash_case_factory(
             machine=machine,
             atm_grid_name=atm_grid_name,
             ninst=ninst,
-            do_exec=do_exec,
         )
         if configure_forcings:
             case.configure_forcings(

--- a/tests/fixtures/state.py
+++ b/tests/fixtures/state.py
@@ -26,12 +26,28 @@ def is_github_actions():
 
 @pytest.fixture(scope="session")
 def get_cesm_root_path(is_glade_file_system):
-    cesmroot = os.getenv("CESMROOT")
-    if is_glade_file_system:
-        # TODO: this must be generalized in some way
-        cesmroot = "/glade/u/home/manishrv/work/installs/full_regional_cesm"
-    elif cesmroot is None:
+    """Path to a CESM checkout, or skip every test that needs one.
 
-        cesmroot = "/Users/manishrv/Documents/cesm"
-        os.environ["CIME_MACHINE"] = "ubuntu-latest"  # macos has problems with VCG
+    $CESMROOT wins, so the suite can be pointed at any checkout without editing this
+    file; otherwise fall back to a known location per platform.
+
+    A checkout is required rather than optional, and CESM_NOT_PORTED does not change
+    that: CIME_interface asserts that <cesmroot>/cime exists and reads compsets, grids
+    and the machine list out of the tree *before* it can decide the host is un-ported.
+    "Un-ported" means CESM is present but this host has no machine definition -- not
+    that CESM is absent. So when there is no checkout to read, skip instead of failing;
+    the ~200 tests that never build a Case are unaffected and still run.
+    """
+    cesmroot = os.getenv("CESMROOT")
+    if cesmroot is None:
+        if is_glade_file_system:
+            cesmroot = "/glade/u/home/manishrv/work/installs/full_regional_cesm"
+        else:
+            cesmroot = "/Users/manishrv/Documents/cesm"
+            os.environ["CIME_MACHINE"] = "ubuntu-latest"  # macos has problems with VCG
+    if not os.path.isdir(os.path.join(cesmroot, "cime")):
+        pytest.skip(
+            f"No CESM checkout at {cesmroot} (no cime/ subdirectory). Set $CESMROOT to "
+            "a CESM checkout to run the tests that build a Case."
+        )
     return cesmroot

--- a/tests/forcing/test_base.py
+++ b/tests/forcing/test_base.py
@@ -93,6 +93,30 @@ class DummyXML(BaseConfigurator):
         super().configure()
 
 
+class DummyUserNL(BaseConfigurator):
+    """UserNLConfigParam counterpart to DummyXML, for the do_exec tests below.
+    Not @register'd, for the same reason DummyXML isn't."""
+
+    name = "dummyusernl"
+
+    input_params = [
+        InputValueParam(
+            "dummy",
+            comment="Boop Boop",
+        )
+    ]
+    output_params = [
+        UserNLConfigParam("DUMMY_NL_VAR", comment="Boop Boop"),
+    ]
+
+    def __init__(self, dummy):
+        super().__init__(dummy=dummy)
+
+    def configure(self):
+        self.set_output_param("DUMMY_NL_VAR", "value")
+        super().configure()
+
+
 @pytest.fixture
 def fcr_add_dummy1():
     return ForcingConfigRegistry("", {"dummy": "dummy"}, None)
@@ -168,7 +192,9 @@ def test_is_non_local_defaults_false_without_case(mock_xmlchange):
     without DummyXML declaring a case_is_non_local input param."""
     obj = DummyXML("x")
     obj.configure()
-    mock_xmlchange.assert_called_once_with("DUMMY_XML_VAR", "value", is_non_local=False)
+    mock_xmlchange.assert_called_once_with(
+        "DUMMY_XML_VAR", "value", do_exec=True, is_non_local=False
+    )
 
 
 @patch("CrocoDash.forcing.base.xmlchange")
@@ -179,7 +205,49 @@ def test_is_non_local_propagates_from_registry_case(mock_xmlchange):
     obj = DummyXML("x")
     obj.registry = SimpleNamespace(case=SimpleNamespace(is_non_local=True))
     obj.configure()
-    mock_xmlchange.assert_called_once_with("DUMMY_XML_VAR", "value", is_non_local=True)
+    mock_xmlchange.assert_called_once_with(
+        "DUMMY_XML_VAR", "value", do_exec=True, is_non_local=True
+    )
+
+
+@patch("CrocoDash.forcing.base.xmlchange")
+def test_do_exec_defaults_true_without_case(mock_xmlchange):
+    """No live Case (direct construction, deserialize()) must keep executing.
+
+    do_exec's default is the opposite of is_non_local's: True, so that every
+    existing caller behaves exactly as it did before do_exec existed.
+    """
+    obj = DummyXML("x")
+    obj.configure()
+    assert mock_xmlchange.call_args.kwargs["do_exec"] is True
+
+
+@patch("CrocoDash.forcing.base.xmlchange")
+def test_do_exec_propagates_from_registry_case(mock_xmlchange):
+    """A Case configured but never created (MACHINE == CESM_NOT_PORTED) must not
+    shell out to xmlchange -- there is no case directory to run it in."""
+    obj = DummyXML("x")
+    obj.registry = SimpleNamespace(case=SimpleNamespace(do_exec=False))
+    obj.configure()
+    assert mock_xmlchange.call_args.kwargs["do_exec"] is False
+
+
+@patch("CrocoDash.forcing.base.append_user_nl")
+def test_do_exec_propagates_to_user_nl_params(mock_append_user_nl):
+    """do_exec must also reach UserNLConfigParam, which (unlike XMLConfigParam)
+    previously hardcoded do_exec=True in apply()."""
+    obj = DummyUserNL("x")
+    obj.registry = SimpleNamespace(case=SimpleNamespace(do_exec=False))
+    obj.configure()
+    assert mock_append_user_nl.call_args.kwargs["do_exec"] is False
+
+
+@patch("CrocoDash.forcing.base.append_user_nl")
+def test_user_nl_do_exec_defaults_true_without_case(mock_append_user_nl):
+    """Same default-True guarantee as the XML path, for user_nl writes."""
+    obj = DummyUserNL("x")
+    obj.configure()
+    assert mock_append_user_nl.call_args.kwargs["do_exec"] is True
 
 
 def test_depends_on_outputs_targets_exist():

--- a/tests/shareable/test_bundle.py
+++ b/tests/shareable/test_bundle.py
@@ -6,19 +6,19 @@ import yaml
 from pathlib import Path
 
 
-@pytest.fixture(scope="session")
-def two_cesm_cases(CrocoDash_case_factory, tmp_path_factory):
-    case1 = CrocoDash_case_factory(
-        tmp_path_factory.mktemp("case1"), configure_forcings=True
-    )
-    case2 = CrocoDash_case_factory(
-        tmp_path_factory.mktemp("case2"), configure_forcings=True
-    )
-    return case1, case2
+@pytest.fixture
+def two_cesm_cases(ported_case_copy):
+    """Two caserootss of a real CIME case, identical until a test perturbs one.
+
+    Both are copies of the single ported case, so the pair costs two directory copies
+    rather than two create_newcase runs. Function-scoped because the alldiff test below
+    mutates the first one.
+    """
+    return ported_case_copy("case1"), ported_case_copy("case2")
 
 
 @pytest.fixture
-def fake_RCC_empty_case(get_CrocoDash_case):
+def fake_RCC_empty_case(ported_case):
     from unittest.mock import MagicMock
 
     case = CaseBundle.__new__(CaseBundle)
@@ -43,20 +43,20 @@ def fake_RCC_empty_case(get_CrocoDash_case):
     ]
     mock_cime.get_value.side_effect = comp_map.get
     case._case = mock_cime
-    case.cesmroot = get_CrocoDash_case.cesmroot
+    case.cesmroot = ported_case.cesmroot
     return case
 
 
-def test_RCC_init(get_case_with_cf):
-    case = get_case_with_cf
+def test_RCC_init(ported_case):
+    case = ported_case
     rcc = CaseBundle(case.caseroot)
     assert rcc
 
 
 def test_diff_CESM_cases_nodiff(two_cesm_cases):
 
-    case1, case2 = two_cesm_cases
-    output = CaseBundle(case1.caseroot).diff(CaseBundle(case2.caseroot))
+    caseroot1, caseroot2 = two_cesm_cases
+    output = CaseBundle(caseroot1).diff(CaseBundle(caseroot2))
     assert output.xml_files_missing_in_new == []
     for key, value in output.user_nl_missing_params.items():
         assert value == []
@@ -65,36 +65,36 @@ def test_diff_CESM_cases_nodiff(two_cesm_cases):
 
 
 def test_diff_CESM_cases_alldiff(two_cesm_cases):
-    case1, case2 = two_cesm_cases
-    # add in a .xml file to case1.caseroot folder
-    xml_file = Path(case1.caseroot) / "test.xml"
+    caseroot1, caseroot2 = two_cesm_cases
+    # add in a .xml file to caseroot1 folder
+    xml_file = Path(caseroot1) / "test.xml"
     xml_file.write_text("<test>data</test>")
 
     # run subprocess.run xmlchange in case1.caseroot folder for JOB_PRIORITY=premium with -N flag
     subprocess.run(
         ["./xmlchange", "JOB_PRIORITY=premium", "-N"],
-        cwd=case1.caseroot,
+        cwd=caseroot1,
     )
 
-    # add a file to case1.caseroot/SourceMods/src.mom called bleh.dummy
-    srcmods_dir = Path(case1.caseroot) / "SourceMods" / "src.mom"
+    # add a file to caseroot1/SourceMods/src.mom called bleh.dummy
+    srcmods_dir = Path(caseroot1) / "SourceMods" / "src.mom"
     dummy_file = srcmods_dir / "bleh.dummy"
     dummy_file.write_text("dummy content")
 
-    # add a line to case1.caseroot/user_nl_mom with DEBUG=TRUE
-    user_nl_path = Path(case1.caseroot) / "user_nl_mom"
+    # add a line to caseroot1/user_nl_mom with DEBUG=TRUE
+    user_nl_path = Path(caseroot1) / "user_nl_mom"
     with open(user_nl_path, "a") as f:
         f.write("\nDEBUG=TRUE\n")
 
-    output = CaseBundle(case1.caseroot).diff(CaseBundle(case2.caseroot))
+    output = CaseBundle(caseroot1).diff(CaseBundle(caseroot2))
     assert output.xml_files_missing_in_new == ["test.xml"]
     assert output.user_nl_missing_params["mom"] == ["DEBUG"]
     assert output.source_mods_missing_files == ["src.mom/bleh.dummy"]
     assert output.xmlchanges_missing == ["JOB_PRIORITY"]
 
 
-def test_load_state_from_crocodash_init_args(get_case_with_cf):
-    case = get_case_with_cf
+def test_load_state_from_crocodash_init_args(ported_case):
+    case = ported_case
     rcc = CaseBundle(case.caseroot)
     init_args = rcc.init_args
 
@@ -104,45 +104,36 @@ def test_load_state_from_crocodash_init_args(get_case_with_cf):
     assert str(init_args["vgrid_path"]).startswith("ocean_vgrid_pana")
 
 
-def test_load_state_from_crocodash_forcing_config(
-    CrocoDash_case_factory, tmp_path_factory
-):
-    case1 = CrocoDash_case_factory(tmp_path_factory.mktemp("forcing_config_args"))
-    case1.configure_forcings(
-        date_range=["2020-01-01 00:00:00", "2020-01-09 00:00:00"],
-        tidal_constituents=["M2"],
-        tpxo_elevation_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/h_tpxo9.v1.zarr/",
-        tpxo_velocity_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/u_tpxo9.v1.zarr/",
-    )
-    rcc = CaseBundle(case1.caseroot)
+def test_load_state_from_crocodash_forcing_config(ported_case):
+    rcc = CaseBundle(ported_case.caseroot)
     assert "tides" in rcc.forcing_config
 
 
-def test_identify_non_standard_case_information(get_shareable_CrocoDash_case):
+def test_identify_non_standard_case_information(ported_case, ported_case_copy):
 
-    case1 = get_shareable_CrocoDash_case
+    caseroot1 = ported_case_copy("non-standard")
 
-    xml_file = Path(case1.caseroot) / "test.xml"
+    xml_file = Path(caseroot1) / "test.xml"
     xml_file.write_text("<test>data</test>")
 
     # run subprocess.run xmlchange in case1.caseroot folder for JOB_PRIORITY=premium with -N flag
     subprocess.run(
         ["./xmlchange", "JOB_PRIORITY=premium", "-N"],
-        cwd=case1.caseroot,
+        cwd=caseroot1,
     )
 
-    # add a file to case1.caseroot/SourceMods/src.mom called bleh.dummy
-    srcmods_dir = Path(case1.caseroot) / "SourceMods" / "src.mom"
+    # add a file to caseroot1/SourceMods/src.mom called bleh.dummy
+    srcmods_dir = Path(caseroot1) / "SourceMods" / "src.mom"
     dummy_file = srcmods_dir / "bleh.dummy"
     dummy_file.write_text("dummy content")
 
-    # add a line to case1.caseroot/user_nl_mom with DEBUG=TRUE
-    user_nl_path = Path(case1.caseroot) / "user_nl_mom"
+    # add a line to caseroot1/user_nl_mom with DEBUG=TRUE
+    user_nl_path = Path(caseroot1) / "user_nl_mom"
     with open(user_nl_path, "a") as f:
         f.write("\nDEBUG=TRUE\n")
-    rcc = CaseBundle(case1.caseroot)
+    rcc = CaseBundle(caseroot1)
     output = rcc.identify_non_standard_case_info(
-        case1.cime.cimeroot.parent, case1.machine, case1.project
+        ported_case.cime.cimeroot.parent, ported_case.machine, ported_case.project
     )
     assert output.xml_files_missing_in_new == ["test.xml"]
     assert output.user_nl_missing_params["mom"] == ["DEBUG"]
@@ -150,8 +141,8 @@ def test_identify_non_standard_case_information(get_shareable_CrocoDash_case):
     assert output.xmlchanges_missing == ["JOB_PRIORITY"]
 
 
-def test_read_user_nl_mom_lines_as_obj(get_CrocoDash_case):
-    case = get_CrocoDash_case
+def test_read_user_nl_mom_lines_as_obj(ported_case):
+    case = ported_case
     rcc = CaseBundle(case.caseroot)
     rcc.caseroot = case.caseroot
     user_nl_mom_obj = rcc._read_user_nl_lines_as_obj("mom")
@@ -160,9 +151,9 @@ def test_read_user_nl_mom_lines_as_obj(get_CrocoDash_case):
     )
 
 
-def test_get_case_obj(get_CrocoDash_case):
-    case = _get_case_obj(get_CrocoDash_case.caseroot)
-    assert case.get_value("COMPSET") == get_CrocoDash_case.compset_lname + "_SESP"
+def test_get_case_obj(ported_case):
+    case = _get_case_obj(ported_case.caseroot)
+    assert case.get_value("COMPSET") == ported_case.compset_lname + "_SESP"
 
 
 # Need to test xml, sourcemods, user_nls, init
@@ -170,16 +161,20 @@ def test_get_case_obj(get_CrocoDash_case):
 # Add bundle test
 
 
-def test_bundle_with_modifications(CrocoDash_case_factory, tmp_path_factory, tmp_path):
+def test_bundle_with_modifications(ported_case, ported_case_copy, tmp_path):
     """Test bundle with XML files and sourceMods modifications."""
-    case = CrocoDash_case_factory(tmp_path_factory.mktemp(f"case-{uuid4().hex}"))
+    # A copy of the ported case, with its own inputdir because this test seeds fake
+    # forcing files into ocnice. The copy already carries the ported case's forcing
+    # configuration, so there is nothing to configure here.
+    caseroot = ported_case_copy("modifications", with_inputdir=True)
+    inputdir = caseroot.parent / "inputdir"
     # Add modifications to the case
     # 1. Add an XML file
-    xml_file = Path(case.caseroot) / "custom_settings.xml"
+    xml_file = Path(caseroot) / "custom_settings.xml"
     xml_file.write_text("<config><setting>value</setting></config>")
 
     # 2. Add a sourceMods file
-    srcmods_dir = Path(case.caseroot) / "SourceMods" / "src.mom"
+    srcmods_dir = Path(caseroot) / "SourceMods" / "src.mom"
     srcmods_dir.mkdir(parents=True, exist_ok=True)
     srcmods_file = srcmods_dir / "custom_module.F90"
     srcmods_file.write_text(
@@ -187,35 +182,27 @@ def test_bundle_with_modifications(CrocoDash_case_factory, tmp_path_factory, tmp
     )
 
     # 3. Modify user_nl_mom
-    user_nl_path = Path(case.caseroot) / "user_nl_mom"
+    user_nl_path = Path(caseroot) / "user_nl_mom"
     with open(user_nl_path, "a") as f:
         f.write("\nCUSTOM_PARAM=42\n")
 
-    # Configure forcings
-    case.configure_forcings(
-        date_range=["2020-01-01 00:00:00", "2020-01-09 00:00:00"],
-        tidal_constituents=["M2"],
-        tpxo_elevation_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/h_tpxo9.v1.zarr/",
-        tpxo_velocity_filepath="s3://crocodile-cesm/CrocoDash/data/tpxo/u_tpxo9.v1.zarr/",
-    )
-
     # Create fake files in ocnice directory
-    ocnice_dir = Path(case.inputdir) / "ocnice"
+    ocnice_dir = Path(inputdir) / "ocnice"
     (ocnice_dir / "forcing_obc_segment_fake.nc").touch()
     (ocnice_dir / "tz_fake.nc").touch()
 
     output_dir = tmp_path / "bundle_output_modified"
     output_dir.mkdir()
 
-    rcc = CaseBundle(case.caseroot)
+    rcc = CaseBundle(caseroot)
     rcc.identify_non_standard_case_info(
-        case.cime.cimeroot.parent, case.machine, case.project
+        ported_case.cime.cimeroot.parent, ported_case.machine, ported_case.project
     )
     # Run the function
     rcc.bundle(output_dir)
 
     # Check that case_bundle folder was created
-    case_bundle = output_dir / f"{case.caseroot.name}_case_bundle"
+    case_bundle = output_dir / f"{caseroot.name}_case_bundle"
     assert case_bundle.exists()
 
     # Check that XML files were copied
@@ -274,14 +261,14 @@ def test_bundle_with_modifications(CrocoDash_case_factory, tmp_path_factory, tmp
     assert "CUSTOM_PARAM=42" in user_nl_content
 
 
-def test_read_user_nls(fake_RCC_empty_case, get_CrocoDash_case):
+def test_read_user_nls(fake_RCC_empty_case, ported_case):
     rcc = fake_RCC_empty_case
-    rcc.caseroot = get_CrocoDash_case.caseroot
+    rcc.caseroot = ported_case.caseroot
     rcc._read_user_nls()
     assert "mom" in rcc.user_nl_objs.keys()
     assert "datm" in rcc.user_nl_objs.keys()
     assert rcc.get_user_nl_value("mom", "INPUTDIR") == str(
-        get_CrocoDash_case.inputdir / "ocnice"
+        ported_case.inputdir / "ocnice"
     )
 
 

--- a/tests/shareable/test_integration.py
+++ b/tests/shareable/test_integration.py
@@ -8,20 +8,22 @@ import pytest
 
 
 @pytest.mark.slow
-def test_duplicate_case(get_case_with_cf, tmp_path):
-    case = get_case_with_cf
+def test_duplicate_case(ported_case_copy, tmp_path):
+    # A copy with its own inputdir, since the seeded forcing files below would
+    # otherwise land in the inputdir the other ported_case tests read.
+    caseroot = ported_case_copy("duplicate", with_inputdir=True)
     new_caseroot = tmp_path / "duplicated_case"
     new_inputdir = tmp_path / "duplicated_inputdir"
 
     # configure_forcings doesn't produce NetCDF files — seed the ocnice dir
     # with fake forcing files so the copy logic has something to transfer.
-    old_ocnice = Path(case.inputdir) / "ocnice"
+    old_ocnice = caseroot.parent / "inputdir" / "ocnice"
     old_ocnice.mkdir(parents=True, exist_ok=True)
     fake_files = ["forcing_obc_seg_001.nc", "init_temp_salt.nc"]
     for fname in fake_files:
         (old_ocnice / fname).write_text("fake")
 
-    new_case = duplicate_case(case.caseroot, new_caseroot, new_inputdir)
+    new_case = duplicate_case(caseroot, new_caseroot, new_inputdir)
 
     assert new_case is not None
     assert new_caseroot.exists()
@@ -31,8 +33,8 @@ def test_duplicate_case(get_case_with_cf, tmp_path):
 
 
 @pytest.mark.slow
-def test_pass_from_inspect_to_fork_no_change(get_case_with_cf, tmp_path):
-    case = get_case_with_cf
+def test_pass_from_inspect_to_fork_no_change(ported_case, tmp_path):
+    case = ported_case
     rcc = CaseBundle(case.caseroot)
     rcc.identify_non_standard_case_info(rcc.cesmroot, case.machine, case.project)
     loc = rcc.bundle(tmp_path)
@@ -57,29 +59,33 @@ def test_pass_from_inspect_to_fork_no_change(get_case_with_cf, tmp_path):
 
 
 @pytest.mark.slow
-def test_pass_from_inspect_to_fork_with_changes(get_case_with_cf, tmp_path):
-    case = get_case_with_cf
+def test_pass_from_inspect_to_fork_with_changes(
+    ported_case, ported_case_copy, tmp_path
+):
+    caseroot = ported_case_copy("fork-with-changes")
 
-    xml_file = Path(case.caseroot) / "test.xml"
+    xml_file = Path(caseroot) / "test.xml"
     xml_file.write_text("<test>data</test>")
 
     # run subprocess.run xmlchange in case.caseroot folder for JOB_PRIORITY=premium with -N flag
     subprocess.run(
         ["./xmlchange", "JOB_PRIORITY=premium", "-N"],
-        cwd=case.caseroot,
+        cwd=caseroot,
     )
 
-    # add a file to case.caseroot/SourceMods/src.mom called bleh.dummy
-    srcmods_dir = Path(case.caseroot) / "SourceMods" / "src.mom"
+    # add a file to caseroot/SourceMods/src.mom called bleh.dummy
+    srcmods_dir = Path(caseroot) / "SourceMods" / "src.mom"
     dummy_file = srcmods_dir / "bleh.dummy"
     dummy_file.write_text("dummy content")
 
-    # add a line to case.caseroot/user_nl_mom with DEBUG=TRUE
-    user_nl_path = Path(case.caseroot) / "user_nl_mom"
+    # add a line to caseroot/user_nl_mom with DEBUG=TRUE
+    user_nl_path = Path(caseroot) / "user_nl_mom"
     with open(user_nl_path, "a") as f:
         f.write("\nDEBUG=TRUE\n")
-    rcc = CaseBundle(case.caseroot)
-    rcc.identify_non_standard_case_info(rcc.cesmroot, case.machine, case.project)
+    rcc = CaseBundle(caseroot)
+    rcc.identify_non_standard_case_info(
+        rcc.cesmroot, ported_case.machine, ported_case.project
+    )
     loc = rcc.bundle(tmp_path)
     with patch("CrocoDash.shareable.ask_yes_no", return_value=True), patch(
         "CrocoDash.shareable.ask_string", return_value=""
@@ -87,11 +93,11 @@ def test_pass_from_inspect_to_fork_with_changes(get_case_with_cf, tmp_path):
         fcb = ForkBundle(loc)
         fcb.fork(
             rcc.cesmroot,
-            case.machine,
-            case.project,
+            ported_case.machine,
+            ported_case.project,
             tmp_path / "caseroot",
             tmp_path / "inputdir",
-            compset=case.compset_lname,
+            compset=ported_case.compset_lname,
         )
         path_to_case = fcb.case.caseroot
         assert (path_to_case / "test.xml").exists()

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -18,7 +18,6 @@ def test_case_init_and_create_grid_input(get_CrocoDash_case):
     assert os.path.exists(case.caseroot)
     assert os.path.exists(case.inputdir)
     assert file_with_prefix_exists(case.inputdir / "ocnice", "ocean_hgrid")
-    assert file_with_prefix_exists(case.caseroot, "README")
 
     files = [
         f
@@ -59,12 +58,29 @@ def test_case_init_and_create_grid_input(get_CrocoDash_case):
         assert len(files) > 0
 
 
-def test_configure_forcings(get_case_with_cf):
-    case = get_case_with_cf
+def test_ported_case_has_cime_artifacts(ported_case):
+    """The one case built with do_exec=True must be a real, CIME-created case.
+
+    Everything else in the suite is configured without invoking CIME, so this is what
+    covers the create_newcase/case.setup path: the files below only exist because CIME
+    actually ran.
+    """
+    caseroot = ported_case.caseroot
+    assert file_with_prefix_exists(caseroot, "README")
+    assert (caseroot / "xmlquery").exists()
+    assert (caseroot / "env_case.xml").exists()
+    assert (caseroot / "user_nl_mom").exists()
+    assert (caseroot / "SourceMods").is_dir()
+
+
+def test_configure_forcings(ported_case):
+    # Reads user_nl_mom, which only a CIME-created case has, hence ported_case.
+    case = ported_case
     assert case.expt is not None
     assert case.date_range[0].year == 2020
     assert case.boundaries == ["north", "east"]
     search_string = "OBC_NUMBER_OF_SEGMENTS"
+    found_user_nl_mom_adjusted_var = False
     with open(case.caseroot / "user_nl_mom", "r", encoding="utf-8") as file:
         for line in file:
             if search_string in line:
@@ -73,11 +89,11 @@ def test_configure_forcings(get_case_with_cf):
     assert found_user_nl_mom_adjusted_var
 
 
-def test_configure_forcings_invalid_function_overrides(get_CrocoDash_case):
+def test_configure_forcings_invalid_function_overrides(get_mutable_CrocoDash_case):
     """
     GLORYS access functions have no non-required args, so any override key is invalid.
     """
-    case = get_CrocoDash_case
+    case = get_mutable_CrocoDash_case
     with pytest.raises(ValueError):
         case.configure_forcings(
             date_range=["2020-01-01 00:00:00", "2020-02-01 00:00:00"],

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -109,6 +109,95 @@ def test_not_ported_machine_recorded_in_state(get_CrocoDash_case):
     assert state["machine"] == "CESM_NOT_PORTED"
 
 
+def test_no_cesm_checkout_configures_case(gen_grid_topo_vgrid, tmp_path):
+    """A case can be configured with no CESM checkout at all -- no cesmroot argument.
+
+    This is the case that genuinely needs no CESM on disk. CIME_interface can't be built
+    without the tree, so _NoCesmCIME stands in for it and the visualCaseGen configuration
+    pipeline is skipped: what that pipeline does is validate the compset and grid names
+    against the catalogue, and there is no catalogue to validate against. Everything that
+    doesn't need CESM still happens.
+    """
+    from CrocoDash.case import Case
+
+    grid, topo, vgrid = gen_grid_topo_vgrid
+    case = Case(
+        caseroot=tmp_path / "case",
+        inputdir=tmp_path / "inputdir",
+        # A long name, not an alias: alias resolution is the one thing that truly
+        # requires the catalogue.
+        compset="1850_DATM%NYF_SLND_SICE_MOM6%REGIONAL_SROF_SGLC_SWAV",
+        ocn_grid=grid,
+        ocn_topo=topo,
+        ocn_vgrid=vgrid,
+        atm_grid_name="T62",
+        override=True,
+    )
+
+    assert case.has_cesm is False
+    assert case.cesmroot is None
+    assert case.machine == "CESM_NOT_PORTED"
+    assert case.do_exec is False
+    assert case.is_non_local is False
+
+    # Grid inputs and the state file are still produced.
+    assert file_with_prefix_exists(case.inputdir / "ocnice", "ocean_hgrid")
+    assert (case.caseroot / "_crocodash_state.json").exists()
+
+    # Forcing extraction never touches CIME, so it still configures.
+    case.configure_forcings(
+        date_range=["2020-01-01 00:00:00", "2020-01-05 00:00:00"],
+        boundaries=["north"],
+    )
+    assert (case.inputdir / "extract_forcings").exists()
+
+    # Nothing CIME writes exists.
+    assert not (case.caseroot / "xmlquery").exists()
+    assert not (case.caseroot / "env_case.xml").exists()
+
+
+def test_no_cesm_checkout_rejects_other_machines(gen_grid_topo_vgrid, tmp_path):
+    """Without a checkout, CESM_NOT_PORTED is the only possible machine, since CIME is
+    what defines every other one. Asking for a real machine has to fail loudly rather
+    than silently downgrade."""
+    from CrocoDash.case import Case
+
+    grid, topo, vgrid = gen_grid_topo_vgrid
+    with pytest.raises(ValueError, match="without a cesmroot"):
+        Case(
+            caseroot=tmp_path / "case",
+            inputdir=tmp_path / "inputdir",
+            compset="1850_DATM%NYF_SLND_SICE_MOM6%REGIONAL_SROF_SGLC_SWAV",
+            ocn_grid=grid,
+            ocn_topo=topo,
+            ocn_vgrid=vgrid,
+            machine="derecho",
+            override=True,
+        )
+
+
+def test_no_cesm_cime_parses_compset_lname():
+    """_NoCesmCIME must split a compset long name exactly as CIME_interface does, and
+    reject one that is too short rather than silently mis-assigning components."""
+    from CrocoDash.case import _NoCesmCIME
+
+    cime = _NoCesmCIME()
+    components = cime.get_components_from_compset_lname(
+        "1850_DATM%NYF_SLND_SICE_MOM6%REGIONAL_SROF_SGLC_SWAV"
+    )
+    assert components == {
+        "ATM": "DATM%NYF",
+        "LND": "SLND",
+        "ICE": "SICE",
+        "OCN": "MOM6%REGIONAL",
+        "ROF": "SROF",
+        "GLC": "SGLC",
+        "WAV": "SWAV",
+    }
+    with pytest.raises(ValueError, match="Invalid compset long name"):
+        cime.get_components_from_compset_lname("1850_DATM_SLND")
+
+
 def test_emulate_not_ported_matches_visualcasegen(monkeypatch, tmp_path):
     """_emulate_not_ported replicates the identity fields of visualCaseGen's own
     _handle_machine_not_ported instead of calling it, so that a test run does not create

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -59,7 +59,7 @@ def test_case_init_and_create_grid_input(get_CrocoDash_case):
 
 
 def test_ported_case_has_cime_artifacts(ported_case):
-    """The one case built with do_exec=True must be a real, CIME-created case.
+    """The one case built on a ported machine must be a real, CIME-created case.
 
     Everything else in the suite is configured without invoking CIME, so this is what
     covers the create_newcase/case.setup path: the files below only exist because CIME
@@ -71,6 +71,75 @@ def test_ported_case_has_cime_artifacts(ported_case):
     assert (caseroot / "env_case.xml").exists()
     assert (caseroot / "user_nl_mom").exists()
     assert (caseroot / "SourceMods").is_dir()
+
+
+def test_not_ported_machine_configures_without_cime(get_CrocoDash_case):
+    """The complement of test_ported_case_has_cime_artifacts: CESM_NOT_PORTED must
+    configure everything CIME is not needed for, and invoke CIME for nothing.
+
+    This is the un-ported path itself, not a stand-in for it. CESM_NOT_PORTED is
+    visualCaseGen's placeholder rather than a CIME machine, so requesting it works on any
+    host -- which is what makes the path assertable here rather than only on a laptop with
+    an unported CESM checkout.
+    """
+    case = get_CrocoDash_case
+    assert case.machine == "CESM_NOT_PORTED"
+    assert case.do_exec is False
+
+    # Everything that does not need CIME still happened.
+    assert case.caseroot.exists()
+    assert file_with_prefix_exists(case.inputdir / "ocnice", "ocean_hgrid")
+    assert (case.caseroot / "_crocodash_state.json").exists()
+
+    # Nothing create_newcase or case.setup would have written exists.
+    assert not (case.caseroot / "xmlquery").exists()
+    assert not (case.caseroot / "env_case.xml").exists()
+    assert not (case.caseroot / "SourceMods").exists()
+    assert not file_with_prefix_exists(case.caseroot, "README")
+
+
+def test_not_ported_machine_recorded_in_state(get_CrocoDash_case):
+    """The state file records the placeholder machine, so a later replay on a ported
+    machine has to override it rather than silently inheriting a case CIME never ran."""
+    import json
+
+    state = json.loads(
+        (get_CrocoDash_case.caseroot / "_crocodash_state.json").read_text()
+    )
+    assert state["machine"] == "CESM_NOT_PORTED"
+
+
+def test_emulate_not_ported_matches_visualcasegen(monkeypatch, tmp_path):
+    """_emulate_not_ported replicates the identity fields of visualCaseGen's own
+    _handle_machine_not_ported instead of calling it, so that a test run does not create
+    ~/scratch and ~/inputdata as a side effect. Replication can drift from the original,
+    so pin the two together here.
+
+    Only the identity fields are compared: the data roots are intentionally different,
+    since on a ported host the machine's real CIME_OUTPUT_ROOT/DIN_LOC_ROOT already exist
+    and are the correct place to write.
+    """
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from visualCaseGen.cime_interface import CIME_interface
+    from CrocoDash import case as case_module
+
+    # Redirect $HOME so the handler's mkdirs land in tmp_path.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    reference = SimpleNamespace()
+    CIME_interface._handle_machine_not_ported(reference)
+
+    # _emulate_not_ported refreshes the MACHINE option list, which needs cvars.
+    machine_var = SimpleNamespace(options=["derecho", "casper"])
+    monkeypatch.setattr(case_module, "cvars", {"MACHINE": machine_var})
+    emulated = SimpleNamespace(machine="derecho")
+    case_module._emulate_not_ported(emulated)
+
+    assert emulated.machine == reference.machine
+    assert emulated.machines == reference.machines
+    assert emulated.project_required == reference.project_required
+    assert machine_var.options == reference.machines
 
 
 def test_configure_forcings(ported_case):


### PR DESCRIPTION
**Descrip:**

Lets CrocoDash configure a case on a machine CESM isn't ported to — or with no CESM checkout at all — and makes the test suite roughly twice as fast as a side effect. visualCaseGen already falls back to the `CESM_NOT_PORTED` placeholder when CIME can't identify the host, but `CaseCreator` then refuses to create a case.

**Changes:**

1. **`cesmroot` is now optional.** `CESM_NOT_PORTED` alone couldn't get us here — reaching that placeholder already requires reading CIME, and it only patches host fields, not the model catalogue. So we skip some steps: `_configure_case` doesn't run (it's pure validation, and without a checkout there's nothing to validate against), and `_NoCesmCIME` supplies the little CrocoDash actually needs — `comp_classes` and `get_components_from_compset_lname` off the compset long name, `cime_output_root`/`machine` off the placeholder.

2. Deliberate trade, and `Case` prints it: a typo in a compset long name or a bogus grid name is no longer caught at configure time and will surface when the case is created on a ported machine. A compset *alias* can't be resolved at all in this mode — alias resolution is the one thing that genuinely needs the catalogue — so a long name is required. Passing a real machine with no `cesmroot` is an error, not a silent downgrade.

3. Test suite: one real CESM case instead of ten. `create_newcase` + `case.setup` was ~6.5 s of the ~10 s per case, paid ten times over for fixtures that never look at a CIME artifact. Now one `ported_case` fixture runs CIME and the rest ask for `CESM_NOT_PORTED`; mutating tests copy the ported case, which needs the original's paths rewritten out or `xmlchange` appends to the *original* case's `replay.sh`. Full suite 121.6 s → 67.8 s, case-heavy files 71.6 s → 35.4 s. `$CESMROOT` now takes precedence over a hardcoded personal install, and a missing checkout skips rather than fails: 238 of 263 tests need no CESM.

**Minor changes:**

- `Case.expt` raised `AttributeError` when the case was never created — a real hole for un-ported users, not just tests.
- `session_id` was read back out of `cvars` in four places despite CrocoDash generating it; now a plain attribute the cvar mirrors.
- `is_non_local` was re-derived from `self.cc` at ten call sites; resolved once in `__init__`.
- `_create_newcase` swallowed every exception, so a half-created case looked identical to a working one until something later tripped over a file `case.setup` never wrote. It now reverts its `ccs_config` edits and re-raises. **This may surface previously-hidden failures loudly, which is the intent.**
- `bundle_case` won't work from a case CIME never created — `CaseBundle.__init__` runs `./xmlquery`. Configure and process forcings locally, then recreate on a ported machine via `create_case_from_yaml`.
- `test_diff_CESM_cases_nodiff` is weaker now: two copies of one case make "no differences" closer to a tautology.
- The un-ported *trigger* still isn't reachable in tests — unsetting `NCAR_HOST` isn't enough, because visualCaseGen force-selects `casper` from the fqdn on a JupyterHub node. `test_emulate_not_ported_matches_visualcasegen` pins the emulated state against visualCaseGen's own handler instead, so they can't drift.
